### PR TITLE
fix: scraps 삭제시 tags 함께 삭제

### DIFF
--- a/src/scraps/scraps.service.ts
+++ b/src/scraps/scraps.service.ts
@@ -94,7 +94,7 @@ export class ScrapsService {
   ): Promise<Scrap[]> {
     const query = { user: { userId } };
     let orderBy: any = { createdAt: 'DESC' };
-    
+
     switch (sortBy) {
       case 'created_at':
         orderBy = { createdAt: sortOrder };
@@ -147,8 +147,14 @@ export class ScrapsService {
   }
 
   async remove(scrapId: number): Promise<void> {
-    const scrap = await this.scrapRepository.findOne({ scrapId });
+    const scrap = await this.scrapRepository.findOne({ scrapId }, {
+      populate: ['tags'],
+    });
+
     if (scrap) {
+      if (scrap.tags.length > 0) {
+        await this.em.removeAndFlush(scrap.tags);
+      }
       await this.em.removeAndFlush(scrap);
     }
   }


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->

## 📋 변경사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
scrap 삭제시 tag 연관관계로 인해 에러 발생.
scraps.service.ts 에서 삭제시 tags도 같이 삭제

### 주요 변경사항
- [x] 버그 수정

## 🛠 구현 내용
populate 로 tags 연관관계 함께 조회후 삭제해줌.