### PR TITLE
[CHI-228] 로그인 refresh 이슈 해결 및 tag 기능 수정

### DIFF
--- a/src/api/scraps/scraps.controller.ts
+++ b/src/api/scraps/scraps.controller.ts
@@ -275,7 +275,7 @@ export class ScrapsController {
       }
 
       // 태그 존재 및 권한 확인 후 삭제
-      await this.tagsService.removeFromScrap(userId, scrapId, tagId);
+      await this.tagsService.remove(tagId);
       return { message: 'Tag removed from scrap successfully' };
     } catch (error: any) {
       if (error instanceof HttpException) {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -43,6 +43,9 @@ export class GoogleAuthRequestDto {
  * 토큰 갱신 요청 DTO
  */
 export class RefreshTokenDto {
+  @ApiProperty({ description: 'Refresh token for token renewal' })
+  @IsString()
+  @IsNotEmpty()
   refreshToken: string;
 }
 

--- a/src/tags/entities/tag.entity.ts
+++ b/src/tags/entities/tag.entity.ts
@@ -10,9 +10,6 @@ export class Tag {
     @Property({ name: 'name', type: 'varchar', length: 100 })
     name: string;
 
-    @Property({ name: 'is_deleted', type: 'boolean', default: false })
-    isDeleted: boolean = false;
-
     @Property({ name: 'created_at' })
     createdAt: Date = new Date();
 

--- a/src/tags/tags.service.ts
+++ b/src/tags/tags.service.ts
@@ -94,26 +94,11 @@ export class TagsService {
   }
 
   async remove(tagId: number): Promise<void> {
-    const tag = await this.tagRepository.findOne({ tagId, isDeleted: false });
+    const tag = await this.tagRepository.findOne({ tagId });
     if (tag) {
-      tag.isDeleted = true;
-      await this.em.persistAndFlush(tag);
+      await this.em.removeAndFlush(tag);
     }
   }
-
-  async removeFromScrap(userId: number, scrapId: number, tagId: number): Promise<void> {
-    const tag = await this.tagRepository.findOne({
-      tagId,
-      user: { userId },
-      scrap: { scrapId, isDeleted: false }
-    });
-
-    if (tag) {
-      tag.isDeleted = true;
-      await this.em.persistAndFlush(tag);
-    }
-  }
-
   /**
    * 태그명으로 검색
    */


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-228](https://linear.app/chill-mato/issue/CHI-228/)

## 📋 변경사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
tags의 soft delete 기능 삭제. -> 컬럼 삭제

refresh token으로 access token 미발급 오류 -> DTO에 ApiProperty, validate 추가