### PR TITLE
[CHI-255] json 전송 용량 10mb로 확장

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { VersioningType, ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import * as bodyParser from 'body-parser';
 // Removed Supabase config import
 
 async function bootstrap() {
@@ -13,6 +14,9 @@ async function bootstrap() {
     forbidNonWhitelisted: true,
     transform: true,
   }));
+
+  app.use(bodyParser.json({ limit: '10mb' }));
+  app.use(bodyParser.urlencoded({ limit: '10mb', extended: true }));
 
   // JWT 인증 설정 확인
   console.log('🔐 JWT authentication enabled');


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-255](https://linear.app/chill-mato/issue/CHI-255/)

## 📋 변경사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
nestjs 에서 json 크기 payload too large 에러 발생.
nestjs issue 확인 후 해결 완료

## 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음

## 참고 자료
- [NestJS Issue](https://github.com/nestjs/nest/issues/529#issuecomment-376576929)
