### PR TITLE
[HOTFIX][CHI-271] 스크랩 title dto 최대 길이 제한으로 인한 에러 해결

### DIFF
--- a/src/api/scraps/dto/create-scrap.dto.ts
+++ b/src/api/scraps/dto/create-scrap.dto.ts
@@ -9,7 +9,6 @@ export class CreateScrapDto {
 
   @ApiProperty()
   @IsString()
-  @MaxLength(500)
   title: string;
 
   @ApiProperty()

--- a/src/api/scraps/dto/update-scrap.dto.ts
+++ b/src/api/scraps/dto/update-scrap.dto.ts
@@ -13,7 +13,6 @@ export class UpdateScrapDto extends PartialType(CreateScrapDto) {
   @ApiProperty()
   @IsOptional()
   @IsString()
-  @MaxLength(500)
   title?: string;
 
 


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-271](https://linear.app/chill-mato/issue/CHI-271/)

## 📋 변경사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
데이터베이스에서 title이 text로 길이제한이 없는 데, DTO에 길이제한을 둬 스크랩 생성 시 400 에러 발생 한 문제 발생.
DTO에서 Maxlength 제거
<img width="500" height="251" alt="스크린샷 2025-08-22 오전 12 31 06" src="https://github.com/user-attachments/assets/fd64d4c5-9cfe-4c35-8572-4982802ac132" />


## 🗃️ 데이터베이스 변경사항
없음

## 📦 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음
