### PR TITLE
[CHI-272] agent 모듈 노드별 분리

### DIFF
--- a/src/agent/nodes/article-reflector/index.ts
+++ b/src/agent/nodes/article-reflector/index.ts
@@ -1,0 +1,69 @@
+import { Logger } from '@nestjs/common';
+import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
+import { StringOutputParser } from '@langchain/core/output_parsers';
+import { NewsletterStateAnnotation, NodeResult, Feedback } from '../../types';
+import { NewsletterPromptTemplatesService } from '../../newsletter-prompt-templates.service';
+
+/**
+ * 아티클 리플렉터 노드
+ * 생성된 뉴스레터의 품질을 평가하고 개선 피드백 제공
+ */
+export class ArticleReflectorNode {
+  private readonly logger = new Logger('ArticleReflectorNode');
+
+  constructor(
+    private readonly reflectorModel: ChatGoogleGenerativeAI,
+    private readonly promptTemplatesService: NewsletterPromptTemplatesService,
+  ) {}
+
+  async execute(
+    state: typeof NewsletterStateAnnotation.State,
+  ): Promise<NodeResult> {
+    try {
+      const iteration = state.countOfReflector || 0;
+      this.logger.log(`🔍 Running article reflector (iteration: ${iteration})`);
+
+      // 리플렉터 템플릿 가져오기
+      const template = this.promptTemplatesService.getArticleReflectorTemplate();
+      const chain = template.pipe(this.reflectorModel).pipe(new StringOutputParser());
+
+      // 품질 평가 및 피드백 생성
+      const result = await chain.invoke({
+        topic: state.topic || '없음',
+        keyInsight: state.keyInsight || '없음',
+        generationParams: state.generationParams || '없음',
+        content: state.content || '없음',
+      });
+
+      // 피드백 파싱
+      let feedback: string;
+      try {
+        const parsedResult = JSON.parse(result);
+        feedback = parsedResult.feedback || result;
+      } catch {
+        feedback = result;
+      }
+
+      this.logger.log('Article reflection completed');
+
+      // 피드백 히스토리 업데이트
+      const newFeedback: Feedback = {
+        generatedNewsletter: state.content || '',
+        feedback,
+      };
+
+      return {
+        feedbacks: [...(state.feedbacks || []), newFeedback],
+      };
+    } catch (error) {
+      this.logger.error('Article reflection error:', error);
+      
+      return {
+        warnings: [
+          ...(state.warnings || []),
+          '품질 검토 중 오류가 발생했습니다.',
+        ],
+      };
+    }
+  }
+}

--- a/src/agent/nodes/generate-newsletter-title/index.ts
+++ b/src/agent/nodes/generate-newsletter-title/index.ts
@@ -1,0 +1,55 @@
+import { Logger } from '@nestjs/common';
+import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
+import { StringOutputParser } from '@langchain/core/output_parsers';
+import { NewsletterStateAnnotation, NodeResult } from '../../types';
+import { NewsletterPromptTemplatesService } from '../../newsletter-prompt-templates.service';
+
+/**
+ * 뉴스레터 제목 생성 노드
+ * 생성된 뉴스레터 콘텐츠를 기반으로 제목 생성
+ */
+export class GenerateNewsletterTitleNode {
+  private readonly logger = new Logger('GenerateNewsletterTitleNode');
+
+  constructor(
+    private readonly titleModel: ChatGoogleGenerativeAI,
+    private readonly promptTemplatesService: NewsletterPromptTemplatesService,
+  ) {}
+
+  async execute(
+    state: typeof NewsletterStateAnnotation.State,
+  ): Promise<NodeResult> {
+    try {
+      this.logger.log('📝 Generating newsletter title');
+
+      // 제목 생성 템플릿 가져오기
+      const template = this.promptTemplatesService.getSimpleNewsletterTitleTemplate();
+      const chain = template.pipe(this.titleModel).pipe(new StringOutputParser());
+
+      // 제목 생성
+      const result = await chain.invoke({
+        topic: state.topic,
+        keyInsight: state.keyInsight || '없음',
+        generationParams: state.generationParams || '없음',
+        content: state.content,
+      });
+
+      this.logger.log('Title generated successfully');
+
+      return {
+        title: result.trim(),
+      };
+    } catch (error) {
+      this.logger.error('Title generation error:', error);
+      
+      // 에러 발생 시 기본 제목 사용
+      return {
+        title: `${state.topic} 뉴스레터`,
+        warnings: [
+          ...(state.warnings || []),
+          '제목 생성에 실패하여 기본 제목을 사용합니다.',
+        ],
+      };
+    }
+  }
+}

--- a/src/agent/nodes/generate-newsletter/index.ts
+++ b/src/agent/nodes/generate-newsletter/index.ts
@@ -1,0 +1,66 @@
+import { Logger } from '@nestjs/common';
+import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
+import { StringOutputParser } from '@langchain/core/output_parsers';
+import { NewsletterStateAnnotation, NodeResult } from '../../types';
+import { NewsletterPromptTemplatesService } from '../../newsletter-prompt-templates.service';
+
+/**
+ * 뉴스레터 생성 노드
+ * AI를 사용하여 실제 뉴스레터 콘텐츠를 생성
+ */
+export class GenerateNewsletterNode {
+  private readonly logger = new Logger('GenerateNewsletterNode');
+
+  constructor(
+    private readonly model: ChatGoogleGenerativeAI,
+    private readonly promptTemplatesService: NewsletterPromptTemplatesService,
+  ) {}
+
+  async execute(
+    state: typeof NewsletterStateAnnotation.State,
+  ): Promise<NodeResult> {
+    const processingSteps = [
+      ...(state.processingSteps || []),
+      'newsletter_generation',
+    ];
+
+    try {
+      const iteration = (state.countOfReflector || 0) + 1;
+      this.logger.log(`📝 Generating newsletter (iteration: ${iteration})`);
+
+      // 프롬프트 템플릿 가져오기
+      const template = this.promptTemplatesService.getSimpleNewsletterTemplate();
+      const chain = template.pipe(this.model).pipe(new StringOutputParser());
+
+      // 뉴스레터 생성
+      const result = await chain.invoke({
+        topic: state.topic,
+        keyInsight: state.keyInsight || '없음',
+        generationParams: state.generationParams || '없음',
+        scrapContent: state.scrapContent || '없음',
+        articleStructureTemplate: state.articleStructureTemplate || '없음',
+        feedbacks: state.feedbacks?.length ? JSON.stringify(state.feedbacks) : '없음',
+      });
+
+      this.logger.log('Newsletter generated successfully');
+
+      return {
+        content: result,
+        analysisReason: 'AI 모델로 생성된 뉴스레터입니다.',
+        processingSteps,
+        countOfReflector: iteration,
+      };
+    } catch (error) {
+      this.logger.error('Newsletter generation error:', error);
+      
+      return {
+        processingSteps,
+        errors: [
+          ...(state.errors || []),
+          '뉴스레터 생성 중 오류가 발생했습니다.',
+        ],
+        content: `${state.topic}에 대한 기본 뉴스레터 내용입니다.`,
+      };
+    }
+  }
+}

--- a/src/agent/nodes/index.ts
+++ b/src/agent/nodes/index.ts
@@ -1,0 +1,9 @@
+/**
+ * 워크플로우 노드 모음
+ */
+
+export { PrepareScrapContentNode } from './prepare-scrap-content';
+export { GenerateNewsletterNode } from './generate-newsletter';
+export { GenerateNewsletterTitleNode } from './generate-newsletter-title';
+export { ArticleReflectorNode } from './article-reflector';
+export { RewriteWritingStyleNode } from './rewrite-writing-style';

--- a/src/agent/nodes/prepare-scrap-content/index.ts
+++ b/src/agent/nodes/prepare-scrap-content/index.ts
@@ -1,0 +1,64 @@
+import { Logger } from '@nestjs/common';
+import { NewsletterStateAnnotation, NodeResult } from '../../types';
+import { ScrapCombinationService } from '../../scrap-combination.service';
+
+/**
+ * 스크랩 콘텐츠 준비 노드
+ * 스크랩 데이터를 AI 프롬프트에 사용할 수 있는 형태로 변환
+ */
+export class PrepareScrapContentNode {
+  private readonly logger = new Logger('PrepareScrapContentNode');
+
+  constructor(
+    private readonly scrapCombinationService: ScrapCombinationService,
+  ) {}
+
+  async execute(
+    state: typeof NewsletterStateAnnotation.State,
+  ): Promise<NodeResult> {
+    const processingSteps = [
+      ...(state.processingSteps || []),
+      'scrap_content_preparation',
+    ];
+
+    try {
+      // 스크랩 데이터가 없는 경우 처리
+      if (!state.scrapsWithComments?.length) {
+        this.logger.warn('No scrap data provided');
+        return {
+          processingSteps,
+          warnings: [
+            ...(state.warnings || []),
+            '스크랩 데이터가 제공되지 않았습니다.',
+          ],
+          scrapContent: '스크랩 데이터 없음. 주제와 핵심 인사이트만으로 진행합니다.',
+        };
+      }
+
+      this.logger.log(`Preparing ${state.scrapsWithComments.length} scraps for AI processing`);
+
+      // 스크랩 데이터를 AI 프롬프트 형식으로 변환
+      const scrapContent = await this.scrapCombinationService.formatForAiPromptWithComments(
+        state.scrapsWithComments,
+      );
+
+      this.logger.log('Scrap content prepared successfully');
+
+      return {
+        scrapContent,
+        processingSteps,
+      };
+    } catch (error) {
+      this.logger.error('Error preparing scrap content:', error);
+      
+      return {
+        processingSteps,
+        errors: [
+          ...(state.errors || []),
+          '스크랩 데이터를 준비하는 중 오류가 발생했습니다.',
+        ],
+        scrapContent: '스크랩 데이터 처리 실패. 기본 템플릿으로 진행합니다.',
+      };
+    }
+  }
+}

--- a/src/agent/nodes/rewrite-writing-style/index.ts
+++ b/src/agent/nodes/rewrite-writing-style/index.ts
@@ -1,0 +1,61 @@
+import { Logger } from '@nestjs/common';
+import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
+import { StringOutputParser } from '@langchain/core/output_parsers';
+import { NewsletterStateAnnotation, NodeResult } from '../../types';
+import { NewsletterPromptTemplatesService } from '../../newsletter-prompt-templates.service';
+
+/**
+ * 글쓰기 스타일 재작성 노드
+ * 사용자의 글쓰기 스타일에 맞게 뉴스레터를 재작성
+ */
+export class RewriteWritingStyleNode {
+  private readonly logger = new Logger('RewriteWritingStyleNode');
+
+  constructor(
+    private readonly rewriteModel: ChatGoogleGenerativeAI,
+    private readonly promptTemplatesService: NewsletterPromptTemplatesService,
+  ) {}
+
+  async execute(
+    state: typeof NewsletterStateAnnotation.State,
+  ): Promise<NodeResult> {
+    try {
+      // 글쓰기 스타일 예시가 없으면 스킵
+      if (!state.writingStyleExampleContents?.length) {
+        this.logger.log('No writing style examples provided, skipping rewrite');
+        return {};
+      }
+
+      this.logger.log('✍️ Rewriting with user writing style');
+
+      // 재작성 템플릿 가져오기
+      const template = this.promptTemplatesService.getWritingStyleRewriteTemplate();
+      const chain = template.pipe(this.rewriteModel).pipe(new StringOutputParser());
+
+      // 스타일에 맞게 재작성
+      const result = await chain.invoke({
+        content: state.content,
+        writingStyleExampleContents: state.writingStyleExampleContents.join('\n\n---\n\n'),
+      });
+
+      this.logger.log('Writing style rewrite completed');
+
+      return {
+        content: result,
+        processingSteps: [
+          ...(state.processingSteps || []),
+          'writing_style_rewrite',
+        ],
+      };
+    } catch (error) {
+      this.logger.error('Writing style rewrite error:', error);
+      
+      return {
+        warnings: [
+          ...(state.warnings || []),
+          '글쓰기 스타일 재작성 중 오류가 발생했습니다. 원본 콘텐츠를 사용합니다.',
+        ],
+      };
+    }
+  }
+}

--- a/src/agent/scrap-combination.service.ts
+++ b/src/agent/scrap-combination.service.ts
@@ -8,25 +8,7 @@ import {
   createModelInitConfig,
   APIKeyValidationError,
 } from './config/ai-models.config';
-
-export interface ScrapWithComment {
-  scrap: Scrap;
-  userComment?: string;
-}
-
-export interface CombinedScrapData {
-  mainContent: string;
-  sources: ScrapSource[];
-  keyPoints: string[];
-  userComments: string[];
-}
-
-export interface ScrapSource {
-  title: string;
-  url: string;
-  summary: string;
-  userComment?: string;
-}
+import { ScrapWithComment } from './types';
 
 @Injectable()
 export class ScrapCombinationService {

--- a/src/agent/types/index.ts
+++ b/src/agent/types/index.ts
@@ -1,0 +1,78 @@
+import { Annotation } from '@langchain/langgraph';
+import { Scrap } from '../../scraps/entities/scrap.entity';
+import { SectionTemplate } from '../../types/section-template';
+
+/**
+ * 스크랩과 코멘트 데이터
+ */
+export interface ScrapWithComment {
+  scrap: Scrap;
+  userComment?: string;
+}
+
+/**
+ * 피드백 데이터 타입
+ */
+export interface Feedback {
+  generatedNewsletter: string;
+  feedback: string;
+}
+
+/**
+ * 뉴스레터 워크플로우 상태 타입
+ */
+export const NewsletterStateAnnotation = Annotation.Root({
+  // 입력 데이터
+  topic: Annotation<string>,
+  keyInsight: Annotation<string | undefined>,
+  scrapsWithComments: Annotation<ScrapWithComment[]>,
+  generationParams: Annotation<string | undefined>,
+  articleStructureTemplate: Annotation<SectionTemplate[] | undefined>,
+  writingStyleExampleContents: Annotation<string[] | undefined>,
+  
+  // 중간 처리 데이터
+  scrapContent: Annotation<string>,
+  countOfReflector: Annotation<number>,
+  feedbacks: Annotation<Feedback[]>,
+  
+  // 최종 결과
+  title: Annotation<string>,
+  content: Annotation<string>,
+  
+  // 메타데이터
+  processingSteps: Annotation<string[]>,
+  warnings: Annotation<string[]>,
+  errors: Annotation<string[]>,
+});
+
+/**
+ * 뉴스레터 입력 데이터
+ */
+export interface NewsletterInput {
+  topic: string;
+  keyInsight?: string;
+  scrapsWithComments: ScrapWithComment[];
+  generationParams?: string;
+  articleStructureTemplate?: SectionTemplate[];
+  writingStyleExampleContents?: string[];
+}
+
+/**
+ * 뉴스레터 출력 데이터
+ */
+export interface NewsletterOutput {
+  title: string;
+  content: string;
+  analysisReason: string;
+  warnings: string[];
+}
+
+/**
+ * 노드 실행 결과 타입
+ */
+export interface NodeResult {
+  [key: string]: any;
+  processingSteps?: string[];
+  warnings?: string[];
+  errors?: string[];
+}


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-272](https://linear.app/chill-mato/issue/CHI-272/)

## 📋 변경사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
Agent 모듈의 복잡도를 줄이기 위해 LangGraph 노드들을 독립적인 폴더 구조로 분리했습니다.


### 주요 변경사항
- 노드별 폴더 구조 생성: 각 워크플로우 노드를 독립적인 폴더로 분리
  - prepare-scrap-content/: 스크랩 데이터 준비
  - generate-newsletter/: 뉴스레터 생성
  - generate-newsletter-title/: 제목 생성
  - article-reflector/: 품질 검토
  - rewrite-writing-style/: 스타일 재작성
- 타입 통합: 모든 타입 정의를 types/index.ts로 중앙화
- 워크플로우 서비스 리팩토링: 분리된 노드 클래스를 사용하도록 수정

## 🗃️ 데이터베이스 변경사항
없음

## 📦 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음
