### PR TITLE
[CHI-283] Supabase에서 RDS PostgreSQL로 데이터베이스 마이그레이션

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -31,6 +31,6 @@ import { WritingStylesModule } from './writing-styles/writing-styles.module';
 })
 export class AppModule {
   constructor() {
-    console.log('🚀 Application module initialized with Supabase OAuth authentication');
+    console.log('🚀 Application module initialized with OAuth authentication');
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,7 +1,7 @@
 /**
  * 인증 컨트롤러
  * 
- * @description Supabase Google OAuth 인증을 위한 REST API 엔드포인트를 제공합니다.
+ * @description Google OAuth 인증을 위한 REST API 엔드포인트를 제공합니다.
  * Linear issue CHI-40 요구사항에 따라 구현되었습니다.
  */
 

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -1,7 +1,7 @@
 /**
- * Supabase JWT 인증 전략
+ * JWT 인증 전략
  * 
- * @description Supabase에서 발급된 JWT 토큰을 검증하는 Passport 전략입니다.
+ * @description JWT 토큰을 검증하는 Passport 전략입니다.
  * Linear issue CHI-40 요구사항에 따라 구현되었습니다.
  */
 

--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -15,10 +15,13 @@ import { WritingStyle } from './writing-styles/entities/writing-style.entity';
 import { WritingStyleExample } from './writing-styles/entities/writing-style-example.entity';
 
 export default defineConfig({
+  host: process.env.DATABASE_HOST,
+  port: Number(process.env.DATABASE_PORT || 5432),
+  dbName: process.env.DATABASE_NAME,
+  user: process.env.DATABASE_USER,
+  password: process.env.DATABASE_PASSWORD,
   // 명시적으로 엔티티 지정
   entities: [Article, ArticleArchive, Scrap, Tag, User, UserOAuth, WritingStyle, WritingStyleExample],
-  clientUrl: process.env.DATABASE_URL,
-  //   dbName: process.env.DATABASE_NAME,
   schema: 'public',
   debug: true,
   allowGlobalContext: true,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -180,7 +180,7 @@ export class UsersService {
   }
 
   /**
-   * 사용자 UUID로 조회 (Supabase JWT의 sub 필드용)
+   * 사용자 UUID로 조회 (JWT의 sub 필드용)
    */
   async findByUuid(uuid: string): Promise<User | null> {
     // UUID는 OAuth ID로 저장되므로 OAuth 테이블에서 조회


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-283](https://linear.app/chill-mato/issue/CHI-283/)

## 📋 변경사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
Supabase 데이터베이스 사용 만료에 따라 RDS PostgreSQL로 마이그레이션을 수행했습니다.

### 주요 변경사항
- **MikroORM 설정 변경**: `clientUrl` 방식에서 개별 환경변수 방식으로 변경
- **환경변수 구조 변경**: `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_NAME`, `DATABASE_USER`, `DATABASE_PASSWORD`로 분리
- **코드 정리**: Supabase 관련 주석 및 로그 메시지를 일반적인 표현으로 수정
- **문서 업데이트**: CLAUDE.md의 환경 설정 가이드를 RDS 기준으로 업데이트

### 기술적 세부사항
- `src/mikro-orm.config.ts`: 개별 환경변수를 사용하도록 설정 변경
- `src/auth/`, `src/users/`: Supabase 관련 주석 제거 및 일반화
- `.env`: RDS 연결을 위한 환경변수 구조로 변경

## 🗃️ 데이터베이스 변경사항
- **이전**: Supabase PostgreSQL (pooler 연결)
- **이후**: AWS RDS PostgreSQL (직접 연결)
- 데이터베이스 스키마 변경 없음 - 연결 방식만 변경

## 📦 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성  
- [x] TypeScript 컴파일 에러 없음

### 배포 시 주의사항
- 새로운 환경변수들이 서버 환경에 설정되어야 함
- RDS 인스턴스가 실행 중이고 접근 가능한 상태여야 함
- 기존 Supabase 관련 환경변수들은 제거 가능