### PR TITLE
[CHI-303] 태그 기능 추가

### DIFF
--- a/src/api/library-items/library-items.controller.ts
+++ b/src/api/library-items/library-items.controller.ts
@@ -10,12 +10,13 @@ import {
   UseInterceptors,
   UploadedFile,
   BadRequestException,
+  Delete,
+  Param,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { LibraryItemsService, LibraryItemDto, LibraryItemType } from '../../library-items/library-items.service';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { CreateScrapDto } from '../scraps/dto/create-scrap.dto';
-import { Param } from '@nestjs/common';
 
 @UseGuards(JwtAuthGuard)
 @Controller('library-items')
@@ -63,6 +64,42 @@ export class LibraryItemsController {
     }
     const userId = parseInt(req.user.id);
     return this.libraryItemsService.uploadViaS3(file, body, userId);
+  }
+
+  @Version('1')
+  @Post(':itemId/tags')
+  async addTag(
+    @Param('itemId') itemId: string,
+    @Query('type') type: LibraryItemType,
+    @Body() body: { name: string },
+    @Request() req: any,
+  ) {
+    const userId = parseInt(req.user.id);
+    return this.libraryItemsService.addTag(parseInt(itemId), type, body.name, userId);
+  }
+
+  @Version('1')
+  @Delete(':itemId/tags/:tagId')
+  async removeTag(
+    @Param('itemId') itemId: string,
+    @Param('tagId') tagId: string,
+    @Query('type') type: LibraryItemType,
+    @Request() req: any,
+  ) {
+    const userId = parseInt(req.user.id);
+    await this.libraryItemsService.removeTag(parseInt(itemId), type, parseInt(tagId), userId);
+    return { success: true };
+  }
+
+  @Version('1')
+  @Get(':itemId/tags')
+  async getTags(
+    @Param('itemId') itemId: string,
+    @Query('type') type: LibraryItemType,
+    @Request() req: any,
+  ) {
+    const userId = parseInt(req.user.id);
+    return this.libraryItemsService.getTags(parseInt(itemId), type, userId);
   }
 
 }

--- a/src/api/library-items/library-items.controller.ts
+++ b/src/api/library-items/library-items.controller.ts
@@ -12,12 +12,17 @@ import {
   BadRequestException,
   Delete,
   Param,
+  ParseEnumPipe,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { LibraryItemsService, LibraryItemDto, LibraryItemType } from '../../library-items/library-items.service';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { CreateScrapDto } from '../scraps/dto/create-scrap.dto';
 
+enum LibraryItemTypeEnum {
+  SCRAP = 'SCRAP',
+  UPLOAD = 'UPLOAD',
+}
 @UseGuards(JwtAuthGuard)
 @Controller('library-items')
 export class LibraryItemsController {
@@ -27,7 +32,7 @@ export class LibraryItemsController {
   @Get()
   async list(
     @Request() req: any,
-    @Query('type') type?: LibraryItemType,
+    @Query('type', new ParseEnumPipe(LibraryItemTypeEnum)) type?: LibraryItemType,
   ): Promise<LibraryItemDto[]> {
     const userId = parseInt(req.user.id);
     return this.libraryItemsService.list(userId, type);
@@ -70,7 +75,7 @@ export class LibraryItemsController {
   @Post(':itemId/tags')
   async addTag(
     @Param('itemId') itemId: string,
-    @Query('type') type: LibraryItemType,
+    @Query('type', new ParseEnumPipe(LibraryItemTypeEnum)) type: LibraryItemType,
     @Body() body: { name: string },
     @Request() req: any,
   ) {
@@ -83,19 +88,23 @@ export class LibraryItemsController {
   async removeTag(
     @Param('itemId') itemId: string,
     @Param('tagId') tagId: string,
-    @Query('type') type: LibraryItemType,
+    @Query('type', new ParseEnumPipe(LibraryItemTypeEnum)) type: LibraryItemType,
     @Request() req: any,
   ) {
     const userId = parseInt(req.user.id);
     await this.libraryItemsService.removeTag(parseInt(itemId), type, parseInt(tagId), userId);
-    return { success: true };
+    return { 
+      success: true,
+      message: 'Tag removed from item successfully',
+      deletedTagId: parseInt(tagId)
+    };
   }
 
   @Version('1')
   @Get(':itemId/tags')
   async getTags(
     @Param('itemId') itemId: string,
-    @Query('type') type: LibraryItemType,
+    @Query('type', new ParseEnumPipe(LibraryItemTypeEnum)) type: LibraryItemType,
     @Request() req: any,
   ) {
     const userId = parseInt(req.user.id);

--- a/src/api/uploaded-files/uploaded-files.controller.ts
+++ b/src/api/uploaded-files/uploaded-files.controller.ts
@@ -89,6 +89,7 @@ export class UploadedFilesController {
   @Delete(':id')
   @UseGuards(JwtAuthGuard)
   remove(@Req() req: any, @Param('id') id: string) {
-    return this.uploadedFilesService.remove(+id, req.user.id);
+    this.uploadedFilesService.remove(+id, req.user.id);
+    return { message: 'Uploaded file deleted successfully' };
   }
 }

--- a/src/library-items/library-items.module.ts
+++ b/src/library-items/library-items.module.ts
@@ -3,6 +3,7 @@ import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { LibraryItemsService } from './library-items.service';
 import { Scrap } from '../scraps/entities/scrap.entity';
 import { UploadedFile } from '../uploaded-files/entities/uploaded-file.entity';
+import { Tag } from '../tags/entities/tag.entity';
 import { LibraryItemsController } from '../api/library-items/library-items.controller';
 import { ScrapsService } from '../scraps/scraps.service';
 import { UploadedFilesService } from '../uploaded-files/uploaded-files.service';
@@ -11,7 +12,7 @@ import { Article } from '../articles/entities/article.entity';
 
 @Module({
   imports: [
-    MikroOrmModule.forFeature([Scrap, UploadedFile, User, Article]),
+    MikroOrmModule.forFeature([Scrap, UploadedFile, Tag, User, Article]),
   ],
   controllers: [LibraryItemsController],
   providers: [LibraryItemsService, ScrapsService, UploadedFilesService],

--- a/src/library-items/library-items.service.ts
+++ b/src/library-items/library-items.service.ts
@@ -1,8 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { Scrap } from '../scraps/entities/scrap.entity';
 import { UploadedFile } from '../uploaded-files/entities/uploaded-file.entity';
+import { Tag } from '../tags/entities/tag.entity';
+import { User } from '../users/entities/user.entity';
 import { ScrapsService } from '../scraps/scraps.service';
 import { UploadedFilesService } from '../uploaded-files/uploaded-files.service';
 import { CreateScrapDto } from '../api/scraps/dto/create-scrap.dto';
@@ -33,6 +35,10 @@ export class LibraryItemsService {
     private readonly scrapRepository: EntityRepository<Scrap>,
     @InjectRepository(UploadedFile)
     private readonly uploadedFileRepository: EntityRepository<UploadedFile>,
+    @InjectRepository(Tag)
+    private readonly tagRepository: EntityRepository<Tag>,
+    @InjectRepository(User)
+    private readonly userRepository: EntityRepository<User>,
     private readonly scrapsService: ScrapsService,
     private readonly uploadedFilesService: UploadedFilesService,
   ) {}
@@ -101,4 +107,92 @@ export class LibraryItemsService {
     createdAt: u.createdAt,
     tags: u.tags?.getItems()?.map(t => t.name),
   });
+
+  // Tag management methods for library items
+  async addTag(itemId: number, itemType: LibraryItemType, tagName: string, userId: number): Promise<Tag> {
+    const user = await this.userRepository.findOne({ userId });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Check if tag already exists for this item
+    let existingTag: Tag | null = null;
+    if (itemType === 'SCRAP') {
+      existingTag = await this.tagRepository.findOne({
+        user: { userId },
+        scrap: { scrapId: itemId },
+        name: tagName,
+      });
+    } else {
+      existingTag = await this.tagRepository.findOne({
+        user: { userId },
+        uploadedFile: { uploadedFileId: itemId },
+        name: tagName,
+      });
+    }
+
+    if (existingTag) {
+      return existingTag;
+    }
+
+    // Create new tag
+    const tag = new Tag();
+    tag.name = tagName;
+    tag.user = user;
+
+    if (itemType === 'SCRAP') {
+      const scrap = await this.scrapRepository.findOne({ scrapId: itemId, user: { userId } });
+      if (!scrap) {
+        throw new NotFoundException('Scrap not found');
+      }
+      tag.scrap = scrap;
+    } else {
+      const uploadedFile = await this.uploadedFileRepository.findOne({ uploadedFileId: itemId, user: { userId } });
+      if (!uploadedFile) {
+        throw new NotFoundException('Uploaded file not found');
+      }
+      tag.uploadedFile = uploadedFile;
+    }
+
+    await this.em.persistAndFlush(tag);
+    return tag;
+  }
+
+  async removeTag(itemId: number, itemType: LibraryItemType, tagId: number, userId: number): Promise<void> {
+    let tag: Tag | null = null;
+    
+    if (itemType === 'SCRAP') {
+      tag = await this.tagRepository.findOne({
+        tagId,
+        user: { userId },
+        scrap: { scrapId: itemId },
+      });
+    } else {
+      tag = await this.tagRepository.findOne({
+        tagId,
+        user: { userId },
+        uploadedFile: { uploadedFileId: itemId },
+      });
+    }
+
+    if (!tag) {
+      throw new NotFoundException('Tag not found');
+    }
+
+    await this.em.removeAndFlush(tag);
+  }
+
+  async getTags(itemId: number, itemType: LibraryItemType, userId: number): Promise<Tag[]> {
+    if (itemType === 'SCRAP') {
+      return this.tagRepository.find({
+        user: { userId },
+        scrap: { scrapId: itemId },
+      });
+    } else {
+      return this.tagRepository.find({
+        user: { userId },
+        uploadedFile: { uploadedFileId: itemId },
+      });
+    }
+  }
 }

--- a/src/tags/entities/tag.entity.ts
+++ b/src/tags/entities/tag.entity.ts
@@ -17,9 +17,9 @@ export class Tag {
     @ManyToOne(() => User, { fieldName: 'user_id' })
     user: User;
 
-    @ManyToOne(() => Scrap, { fieldName: 'scrap_id' })
-    scrap: Scrap;
+    @ManyToOne(() => Scrap, { fieldName: 'scrap_id', nullable: true })
+    scrap?: Scrap;
 
-    @ManyToOne(() => UploadedFile, { fieldName: 'uploaded_file_id' })
-    uploadedFile: UploadedFile;
+    @ManyToOne(() => UploadedFile, { fieldName: 'uploaded_file_id', nullable: true })
+    uploadedFile?: UploadedFile;
 }

--- a/src/tags/entities/tag.entity.ts
+++ b/src/tags/entities/tag.entity.ts
@@ -1,10 +1,22 @@
-import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { BeforeCreate, BeforeUpdate, Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 import { Scrap } from '../../scraps/entities/scrap.entity';
 import { User } from '../../users/entities/user.entity';
 import { UploadedFile } from '../../uploaded-files/entities/uploaded-file.entity';
 
 @Entity({ tableName: 'tags' })
 export class Tag {
+
+    @BeforeCreate()
+    @BeforeUpdate()
+    validate() {
+        const hasScrap = this.scrap !== null && this.scrap !== undefined;
+        const hasUploadedFile = this.uploadedFile !== null && this.uploadedFile !== undefined;
+        if ((hasScrap && hasUploadedFile) || (!hasScrap && !hasUploadedFile)) {
+            throw new Error('Tag must have either scrap or uploaded file');
+        }
+    }
+
+
     @PrimaryKey({ name: 'tag_id' })
     tagId: number;
 


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-303](https://linear.app/chill-mato/issue/CHI-303/)

## 📋 변경사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
-`Tag` 엔티티
  - `scrap_id`, `uploaded_file_id` 둘중 하나 들어가므로 nullable 추가
- `LibraryItems`
  - api: type 파라미터로 scrap, uploaded file과 구분
  - tag 추가/삭제 기능 추가

## 🗃️ 데이터베이스 변경사항
없음

## 📦 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음