### PR TITLE
[CHI-286] 파일(PDF) 업로드 시 AI 요약 생성 기능 추가

### DIFF
--- a/src/api/uploaded-files/uploaded-files.controller.ts
+++ b/src/api/uploaded-files/uploaded-files.controller.ts
@@ -92,4 +92,12 @@ export class UploadedFilesController {
     this.uploadedFilesService.remove(+id, req.user.id);
     return { message: 'Uploaded file deleted successfully' };
   }
+
+  @Version('1')
+  @Get(':id/analysis')
+  @UseGuards(JwtAuthGuard)
+  async getAnalysis(@Req() req: any, @Param('id') id: string) {
+    const data = await this.uploadedFilesService.getAnalysis(+id, req.user.id);
+    return data;
+  }
 }

--- a/src/library-items/library-items.module.ts
+++ b/src/library-items/library-items.module.ts
@@ -9,13 +9,14 @@ import { ScrapsService } from '../scraps/scraps.service';
 import { UploadedFilesService } from '../uploaded-files/uploaded-files.service';
 import { User } from '../users/entities/user.entity';
 import { Article } from '../articles/entities/article.entity';
+import { FileAnalysisAgentService } from '../services/file-analysis-agent.service';
 
 @Module({
   imports: [
     MikroOrmModule.forFeature([Scrap, UploadedFile, Tag, User, Article]),
   ],
   controllers: [LibraryItemsController],
-  providers: [LibraryItemsService, ScrapsService, UploadedFilesService],
+  providers: [LibraryItemsService, ScrapsService, UploadedFilesService, FileAnalysisAgentService],
   exports: [LibraryItemsService],
 })
 export class LibraryItemsModule {}

--- a/src/services/file-analysis-agent.service.ts
+++ b/src/services/file-analysis-agent.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+
+@Injectable()
+export class FileAnalysisAgentService {
+  private readonly logger = new Logger(FileAnalysisAgentService.name);
+  private readonly agentApiUrl: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.agentApiUrl = this.configService.get<string>('TYQUILL_AGENT_API_URL')!;
+    this.logger.log(`🤖 FileAnalysisAgentService initialized with agent URL: ${this.agentApiUrl}`);
+  }
+
+  async analyzeFile(fileUrl: string): Promise<string> {
+    try {
+      this.logger.log('📄 Calling file analysis API');
+
+      const response = await fetch(`${this.agentApiUrl}/api/v1/pdf/analyze`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ fileUrl }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`API call failed: ${response.status} ${response.statusText} - ${errorText}`);
+      }
+
+      const result = await response.json();
+      
+      this.logger.log('✅ File analysis completed successfully');
+      return result;
+    } catch (error) {
+      this.logger.error('❌ File analysis failed:', error);
+      throw error;
+    }
+  }
+}

--- a/src/tags/entities/tag.entity.ts
+++ b/src/tags/entities/tag.entity.ts
@@ -7,7 +7,6 @@ import { UploadedFile } from '../../uploaded-files/entities/uploaded-file.entity
 export class Tag {
 
     @BeforeCreate()
-    @BeforeUpdate()
     validate() {
         const hasScrap = this.scrap !== null && this.scrap !== undefined;
         const hasUploadedFile = this.uploadedFile !== null && this.uploadedFile !== undefined;

--- a/src/uploaded-files/entities/uploaded-file.entity.ts
+++ b/src/uploaded-files/entities/uploaded-file.entity.ts
@@ -25,6 +25,9 @@ export class UploadedFile {
   @Property({ name: 'file_size' })
   fileSize: number;
 
+  @Property({ name: 'ai_content', type: 'text', nullable: true })
+  aiContent?: string;
+
   @Property({ name: 'created_at' })
   createdAt: Date = new Date();
 

--- a/src/uploaded-files/uploaded-files.module.ts
+++ b/src/uploaded-files/uploaded-files.module.ts
@@ -5,6 +5,7 @@ import { UploadedFilesController } from '../api/uploaded-files/uploaded-files.co
 import { UploadedFile } from './entities/uploaded-file.entity';
 import { User } from '../users/entities/user.entity';
 import { AuthModule } from '../auth/auth.module';
+import { FileAnalysisAgentService } from '../services/file-analysis-agent.service';
 
 @Module({
   imports: [
@@ -12,7 +13,7 @@ import { AuthModule } from '../auth/auth.module';
     AuthModule,
   ],
   controllers: [UploadedFilesController],
-  providers: [UploadedFilesService],
+  providers: [UploadedFilesService, FileAnalysisAgentService],
   exports: [UploadedFilesService],
 })
 export class UploadedFilesModule {}

--- a/src/uploaded-files/uploaded-files.service.ts
+++ b/src/uploaded-files/uploaded-files.service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, Injectable, InternalServerErrorException, NotFoundException, Logger } from '@nestjs/common';
 // import { CreateUploadedFileDto } from '../api/uploaded-files/dto/create-uploaded-file.dto';
 import { UpdateUploadedFileDto } from '../api/uploaded-files/dto/update-uploaded-file.dto';
 import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
@@ -7,9 +7,11 @@ import { UploadedFile } from './entities/uploaded-file.entity';
 import { User } from '../users/entities/user.entity';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import * as fs from 'fs';
+import { FileAnalysisAgentService } from '../services/file-analysis-agent.service';
 
 @Injectable()
 export class UploadedFilesService {
+  private readonly logger = new Logger(UploadedFilesService.name);
   private s3Client: S3Client;
   private bucket: string;
 
@@ -19,6 +21,7 @@ export class UploadedFilesService {
     private readonly uploadedFileRepository: EntityRepository<UploadedFile>,
     @InjectRepository(User)
     private readonly userRepository: EntityRepository<User>,
+    private readonly fileAnalysisAgentService: FileAnalysisAgentService,
   ) {
     this.bucket = process.env.AWS_S3_BUCKET || '';
     if (this.bucket === '') {
@@ -91,6 +94,11 @@ export class UploadedFilesService {
     await this.em.removeAndFlush(uploadedFile);
   }
 
+  async getAnalysis(id: number, userId: number): Promise<{ markdown: string | null; updatedAt?: Date }> {
+    const uploaded = await this.findOne(id, userId);
+    return { markdown: uploaded.aiContent ?? null, updatedAt: uploaded.createdAt };
+  }
+
   async uploadToS3AndSave(
     file: Express.Multer.File,
     title: string,
@@ -136,6 +144,11 @@ export class UploadedFilesService {
         fileSize: file.size,
       });
 
+      // PDF 또는 문서 파일인 경우 AI 분석 수행
+      if (this.shouldAnalyzeFile(file.mimetype)) {
+        this.analyzeFileInBackground(uploadedFile, fileUrl);
+      }
+
       // 임시 파일 정리
       if (tmpPath) {
         fs.promises.unlink(tmpPath).catch((error) => {
@@ -174,5 +187,31 @@ export class UploadedFilesService {
 
     await this.em.persistAndFlush(uploadedFile);
     return uploadedFile;
+  }
+
+  private shouldAnalyzeFile(mimeType: string): boolean {
+    const analyzableMimeTypes = [
+      'application/pdf',
+    ];
+    return analyzableMimeTypes.includes(mimeType);
+  }
+
+  private async analyzeFileInBackground(uploadedFile: UploadedFile, fileUrl: string): Promise<void> {
+    try {
+      this.logger.log(`🔍 Starting AI analysis for file: ${uploadedFile.fileName}`);
+
+      const analysisResult = await this.fileAnalysisAgentService.analyzeFile(
+        fileUrl
+      );
+
+      // Update the uploaded file with AI analysis
+      uploadedFile.aiContent = analysisResult;
+      await this.em.flush();
+
+      this.logger.log(`✅ AI analysis completed for file: ${uploadedFile.fileName}`);
+    } catch (error) {
+      this.logger.error(`❌ Failed to analyze file ${uploadedFile.fileName}:`, error);
+      // Don't throw - let the file upload succeed even if analysis fails
+    }
   }
 }


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-286](https://linear.app/chill-mato/issue/CHI-286/)

## 📋 변경사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- `uploaded-files.service.ts`: 업로드 시 요약 생성 기능 추가
- `uploaded-files.controller.ts`: 요약 내용만 가져오는 API 추가
- `file-analysis-agent.ts`: FastAPI 연동 어댑터 추가
- `uploaded-file.entity.ts`: 컬럼 변경
- `tag.entity.ts`: 유효성 검사 `BeforeCreate`시 유효성 검사로 변경

## 🗃️ 데이터베이스 변경사항
- `uploaded-file` 테이블: `ai-content` 컬럼 TEXT 타입 추가

## 📦 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음
