### PR TITLE
[CHI-307] 파일 요약/분석 시 SQS 도입

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,11 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.2.0",
+        "@ssut/nestjs-sqs": "^3.0.1",
         "@types/cheerio": "^0.22.35",
+        "@types/uuid": "^10.0.0",
         "@uploadthing/shared": "^7.1.10",
+        "aws-sdk": "^2.1692.0",
         "axios": "^1.11.0",
         "cheerio": "^1.1.2",
         "class-transformer": "^0.5.1",
@@ -40,7 +43,8 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "turndown": "^7.2.0",
-        "uploadthing": "^7.7.4"
+        "uploadthing": "^7.7.4",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -520,6 +524,379 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.882.0.tgz",
+      "integrity": "sha512-0gd6/iK85pKqnYTdc2hJdxpjg/e1NrrenwPAMpDSmVWdIW8OZnikDzv5Q0WtbSTZadN2uF6a0RLYrxQHEAqoTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.882.0",
+        "@aws-sdk/credential-provider-node": "3.882.0",
+        "@aws-sdk/middleware-host-header": "3.873.0",
+        "@aws-sdk/middleware-logger": "3.876.0",
+        "@aws-sdk/middleware-recursion-detection": "3.873.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.882.0",
+        "@aws-sdk/middleware-user-agent": "3.882.0",
+        "@aws-sdk/region-config-resolver": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.879.0",
+        "@aws-sdk/util-user-agent-browser": "3.873.0",
+        "@aws-sdk/util-user-agent-node": "3.882.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.9.2",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/md5-js": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.21",
+        "@smithy/middleware-retry": "^4.1.22",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.2",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.29",
+        "@smithy/util-defaults-mode-node": "^4.0.29",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.882.0.tgz",
+      "integrity": "sha512-JFWJB+2PZvygDuqb4iWKCro1Tl5L4tGBXMHe94jYMYnfajYGm58bW3RsPj3cKD2+TvIMUSXmNriNv+LbDKZmNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.882.0",
+        "@aws-sdk/middleware-host-header": "3.873.0",
+        "@aws-sdk/middleware-logger": "3.876.0",
+        "@aws-sdk/middleware-recursion-detection": "3.873.0",
+        "@aws-sdk/middleware-user-agent": "3.882.0",
+        "@aws-sdk/region-config-resolver": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.879.0",
+        "@aws-sdk/util-user-agent-browser": "3.873.0",
+        "@aws-sdk/util-user-agent-node": "3.882.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.9.2",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.21",
+        "@smithy/middleware-retry": "^4.1.22",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.2",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.29",
+        "@smithy/util-defaults-mode-node": "^4.0.29",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/core": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.882.0.tgz",
+      "integrity": "sha512-m43/gEDbxqxLT/Mbn/OA21TuFpyocOUzjiSA2HBnLQ3KivA4ez0nsW91vh0Sp3TOfLgiZbRbVhmI6XfsFinwBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/xml-builder": "3.873.0",
+        "@smithy/core": "^3.9.2",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.2",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.882.0.tgz",
+      "integrity": "sha512-khhE1k+4XvGm8Mk6vVUbrVvEnx3r8E6dymSKSiAKf0lwsnKWAWd1RLGwLusqVgtGR4Jfsrbg7ox9MczIjgCiTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.882.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.882.0.tgz",
+      "integrity": "sha512-j3mBF+Q6RU3u8t5O1KOWbQQCi0WNSl47sNIa1RvyN6qK1WIA8BxM1hB25mI9TMPrNZMFthljVec+JcNjRNG34A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.882.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.2",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-stream": "^4.2.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.882.0.tgz",
+      "integrity": "sha512-nUacsSYKyTUmv/Fqe0efihCRCabea5MZtGSZF0l2V8QBo39yJjw0wVmRK6G4bfm5lY7v2EVVIUCpiTvxRRUbHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.882.0",
+        "@aws-sdk/credential-provider-env": "3.882.0",
+        "@aws-sdk/credential-provider-http": "3.882.0",
+        "@aws-sdk/credential-provider-process": "3.882.0",
+        "@aws-sdk/credential-provider-sso": "3.882.0",
+        "@aws-sdk/credential-provider-web-identity": "3.882.0",
+        "@aws-sdk/nested-clients": "3.882.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.882.0.tgz",
+      "integrity": "sha512-sELdV+leCfY+Bw8NQo3H65oIT+9thqZU0RWyv85EfZVvKEwWDt4McA7+Co1VkH+nCY21s5jz4SOqIrYuT0cSQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.882.0",
+        "@aws-sdk/credential-provider-http": "3.882.0",
+        "@aws-sdk/credential-provider-ini": "3.882.0",
+        "@aws-sdk/credential-provider-process": "3.882.0",
+        "@aws-sdk/credential-provider-sso": "3.882.0",
+        "@aws-sdk/credential-provider-web-identity": "3.882.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.882.0.tgz",
+      "integrity": "sha512-S3BgGcaR+L7CQAQn3Ysy9KSnck7+hDicAGM/dYvvJ8GwZNIOc0542Y+ntpV1UYa7OuZPWzGy2v2NcJSCbYDXEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.882.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.882.0.tgz",
+      "integrity": "sha512-1pZRTKiDl6Oh/jP75lEoSkJrer1YEm8lMconB8dX9bsaWbp9cZeMJMK6pts5VQcveeOLr/8/U9TESboPjHBcyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.882.0",
+        "@aws-sdk/core": "3.882.0",
+        "@aws-sdk/token-providers": "3.882.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.882.0.tgz",
+      "integrity": "sha512-EvpsD0Vcz5WgXjpC53KAQ2CkeUp0KwwiV6brgQTXl+9yV/M8M0aK5Qk5ep/MPbAn5gtbqXHaCkiExaN4YYOhCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.882.0",
+        "@aws-sdk/nested-clients": "3.882.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.882.0.tgz",
+      "integrity": "sha512-IdLVpV2b0qryxFb/gNPwZoayLUdgmb41fWpLiIf99pyNwR7TGs/9Ri2amS3PnaQHuES947xYSYZ9Ej0kBgjHKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.882.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.879.0",
+        "@smithy/core": "^3.9.2",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.882.0.tgz",
+      "integrity": "sha512-IQkOtl/DhLV5+tJI7ZwjBDJO1lIoYOcmNQzcg8ly9RTdMoTcEtklevxmAwWB4DEFiIctUk2OSjHqhfWjeYredA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.882.0",
+        "@aws-sdk/middleware-host-header": "3.873.0",
+        "@aws-sdk/middleware-logger": "3.876.0",
+        "@aws-sdk/middleware-recursion-detection": "3.873.0",
+        "@aws-sdk/middleware-user-agent": "3.882.0",
+        "@aws-sdk/region-config-resolver": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.879.0",
+        "@aws-sdk/util-user-agent-browser": "3.873.0",
+        "@aws-sdk/util-user-agent-node": "3.882.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.9.2",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.21",
+        "@smithy/middleware-retry": "^4.1.22",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.2",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.29",
+        "@smithy/util-defaults-mode-node": "^4.0.29",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/token-providers": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.882.0.tgz",
+      "integrity": "sha512-/Z6F8Cc+QjBMEPh3ZXy7JM1vMZCS41+Nh9VgdUwvvdJTA7LRXSDBRDL3cQPa7bii9unZ8SqsIC+7Nlw1LKwwJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.882.0",
+        "@aws-sdk/nested-clients": "3.882.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.882.0.tgz",
+      "integrity": "sha512-7zPtGXeAs6UzKjrrSbMNiFMSLZ/2DWvJ26KBOasS3zQbL534yoNos4HUA3OOXSpKFBAIEcYWu6rzR4ptlvx50w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.882.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.879.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.879.0.tgz",
@@ -865,6 +1242,23 @@
         "@smithy/util-config-provider": "^4.0.0",
         "@smithy/util-middleware": "^4.0.5",
         "@smithy/util-stream": "^4.2.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.882.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.882.0.tgz",
+      "integrity": "sha512-aogk8nuFwEPkclcQ+YPKbmc5p86IVSaY0pPHCU16finL/KtL2+4coByXSa+9/4htNOPzH7EduA+F4E+LxQtn/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/smithy-client": "^4.5.2",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-hex-encoding": "^4.0.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -1844,6 +2238,19 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@golevelup/nestjs-discovery": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@golevelup/nestjs-discovery/-/nestjs-discovery-4.0.3.tgz",
+      "integrity": "sha512-8w3CsXHN7+7Sn2i419Eal1Iw/kOjAd6Kb55M/ZqKBBwACCMn4WiEuzssC71LpBMI1090CiDxuelfPRwwIrQK+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.x || ^11.0.0",
+        "@nestjs/core": "^10.x || ^11.0.0"
       }
     },
     "node_modules/@google/genai": {
@@ -2942,6 +3349,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@langchain/core/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@langchain/google-genai": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-0.2.14.tgz",
@@ -2956,19 +3376,6 @@
       },
       "peerDependencies": {
         "@langchain/core": ">=0.3.58 <0.4.0"
-      }
-    },
-    "node_modules/@langchain/google-genai/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@langchain/langgraph": {
@@ -3010,6 +3417,19 @@
         "@langchain/core": ">=0.2.31 <0.4.0"
       }
     },
+    "node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@langchain/langgraph-sdk": {
       "version": "0.0.92",
       "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-0.0.92.tgz",
@@ -3042,6 +3462,19 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -4527,12 +4960,12 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.5.tgz",
-      "integrity": "sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.1.0.tgz",
+      "integrity": "sha512-wEhSYznxOmx7EdwK1tYEWJF5+/wmSFsff9BfTOn8oO/+KPl3gsmThrb6MJlWbOC391+Ya31s5JuHiC2RlT80Zg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4565,15 +4998,15 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.5.tgz",
-      "integrity": "sha512-viuHMxBAqydkB0AfWwHIdwf/PRH2z5KHGUzqyRtS/Wv+n3IHI993Sk76VCA7dD/+GzgGOmlJDITfPcJC1nIVIw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.2.0.tgz",
+      "integrity": "sha512-FA10YhPFLy23uxeWu7pOM2ctlw+gzbPMTZQwrZ8FRIfyJ/p8YIVz7AVTB5jjLD+QIerydyKcVMZur8qzzDILAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/node-config-provider": "^4.2.0",
+        "@smithy/types": "^4.4.0",
+        "@smithy/util-config-provider": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4581,19 +5014,19 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.9.0.tgz",
-      "integrity": "sha512-B/GknvCfS3llXd/b++hcrwIuqnEozQDnRL4sBmOac5/z/dr0/yG1PURNPOyU4Lsiy1IyTj8scPxVqRs5dYWf6A==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.10.0.tgz",
+      "integrity": "sha512-bXyD3Ij6b1qDymEYlEcF+QIjwb9gObwZNaRjETJsUEvSIzxFdynSQ3E4ysY7lUFSBzeWBNaFvX+5A0smbC2q6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.9",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.5",
-        "@smithy/util-stream": "^4.2.4",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/middleware-serde": "^4.1.0",
+        "@smithy/protocol-http": "^5.2.0",
+        "@smithy/types": "^4.4.0",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.0",
+        "@smithy/util-stream": "^4.3.0",
+        "@smithy/util-utf8": "^4.1.0",
         "@types/uuid": "^9.0.1",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
@@ -4622,15 +5055,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.7.tgz",
-      "integrity": "sha512-dDzrMXA8d8riFNiPvytxn0mNwR4B3h8lgrQ5UjAGu6T9z/kRg/Xncf4tEQHE/+t25sY8IH3CowcmWi+1U5B1Gw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.1.0.tgz",
+      "integrity": "sha512-iVwNhxTsCQTPdp++4C/d9xvaDmuEWhXi55qJobMp9QMaEHRGH3kErU4F8gohtdsawRqnUy/ANylCjKuhcR2mPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/types": "^4.3.2",
-        "@smithy/url-parser": "^4.0.5",
+        "@smithy/node-config-provider": "^4.2.0",
+        "@smithy/property-provider": "^4.1.0",
+        "@smithy/types": "^4.4.0",
+        "@smithy/url-parser": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4708,15 +5141,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz",
-      "integrity": "sha512-61WjM0PWmZJR+SnmzaKI7t7G0UkkNFboDpzIdzSoy7TByUzlxo18Qlh9s71qug4AY4hlH/CwXdubMtkcNEb/sQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.2.0.tgz",
+      "integrity": "sha512-VZenjDdVaUGiy3hwQtxm75nhXZrhFG+3xyL93qCQAlYDyhT/jeDWM8/3r5uCFMlTmmyrIjiDyiOynVFchb0BSg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/querystring-builder": "^4.0.5",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-base64": "^4.0.0",
+        "@smithy/protocol-http": "^5.2.0",
+        "@smithy/querystring-builder": "^4.1.0",
+        "@smithy/types": "^4.4.0",
+        "@smithy/util-base64": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4781,9 +5214,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
-      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.1.0.tgz",
+      "integrity": "sha512-ePTYUOV54wMogio+he4pBybe8fwg4sDvEVDBU8ZlHOZXbXK3/C0XfJgUCu6qAZcawv05ZhZzODGUerFBPsPUDQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4821,18 +5254,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.19",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.19.tgz",
-      "integrity": "sha512-EAlEPncqo03siNZJ9Tm6adKCQ+sw5fNU8ncxWwaH0zTCwMPsgmERTi6CEKaermZdgJb+4Yvh0NFm36HeO4PGgQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.2.0.tgz",
+      "integrity": "sha512-J1eCF7pPDwgv7fGwRd2+Y+H9hlIolF3OZ2PjptonzzyOXXGh/1KGJAHpEcY1EX+WLlclKu2yC5k+9jWXdUG4YQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.9.0",
-        "@smithy/middleware-serde": "^4.0.9",
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/shared-ini-file-loader": "^4.0.5",
-        "@smithy/types": "^4.3.2",
-        "@smithy/url-parser": "^4.0.5",
-        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/core": "^3.10.0",
+        "@smithy/middleware-serde": "^4.1.0",
+        "@smithy/node-config-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.1.0",
+        "@smithy/types": "^4.4.0",
+        "@smithy/url-parser": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4840,18 +5273,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.20",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.20.tgz",
-      "integrity": "sha512-T3maNEm3Masae99eFdx1Q7PIqBBEVOvRd5hralqKZNeIivnoGNx5OFtI3DiZ5gCjUkl0mNondlzSXeVxkinh7Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.2.0.tgz",
+      "integrity": "sha512-raL5oWYf5ALl3jCJrajE8enKJEnV/2wZkKS6mb3ZRY2tg3nj66ssdWy5Ps8E6Yu8Wqh3Tt+Sb9LozjvwZupq+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/service-error-classification": "^4.0.7",
-        "@smithy/smithy-client": "^4.5.0",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-middleware": "^4.0.5",
-        "@smithy/util-retry": "^4.0.7",
+        "@smithy/node-config-provider": "^4.2.0",
+        "@smithy/protocol-http": "^5.2.0",
+        "@smithy/service-error-classification": "^4.1.0",
+        "@smithy/smithy-client": "^4.6.0",
+        "@smithy/types": "^4.4.0",
+        "@smithy/util-middleware": "^4.1.0",
+        "@smithy/util-retry": "^4.1.0",
         "@types/uuid": "^9.0.1",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
@@ -4880,13 +5313,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.9.tgz",
-      "integrity": "sha512-uAFFR4dpeoJPGz8x9mhxp+RPjo5wW0QEEIPPPbLXiRRWeCATf/Km3gKIVR5vaP8bN1kgsPhcEeh+IZvUlBv6Xg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.1.0.tgz",
+      "integrity": "sha512-CtLFYlHt7c2VcztyVRc+25JLV4aGpmaSv9F1sPB0AGFL6S+RPythkqpGDa2XBQLJQooKkjLA1g7Xe4450knShg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/types": "^4.3.2",
+        "@smithy/protocol-http": "^5.2.0",
+        "@smithy/types": "^4.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4894,12 +5327,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.5.tgz",
-      "integrity": "sha512-/yoHDXZPh3ocRVyeWQFvC44u8seu3eYzZRveCMfgMOBcNKnAmOvjbL9+Cp5XKSIi9iYA9PECUuW2teDAk8T+OQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.1.0.tgz",
+      "integrity": "sha512-91Fuw4IKp0eK8PNhMXrHRcYA1jvbZ9BJGT91wwPy3bTQT8mHTcQNius/EhSQTlT9QUI3Ki1wjHeNXbWK0tO8YQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4907,14 +5340,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.4.tgz",
-      "integrity": "sha512-+UDQV/k42jLEPPHSn39l0Bmc4sB1xtdI9Gd47fzo/0PbXzJ7ylgaOByVjF5EeQIumkepnrJyfx86dPa9p47Y+w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.2.0.tgz",
+      "integrity": "sha512-8/fpilqKurQ+f8nFvoFkJ0lrymoMJ+5/CQV5IcTv/MyKhk2Q/EFYCAgTSWHD4nMi9ux9NyBBynkyE9SLg2uSLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/shared-ini-file-loader": "^4.0.5",
-        "@smithy/types": "^4.3.2",
+        "@smithy/property-provider": "^4.1.0",
+        "@smithy/shared-ini-file-loader": "^4.1.0",
+        "@smithy/types": "^4.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4922,15 +5355,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.1.tgz",
-      "integrity": "sha512-RHnlHqFpoVdjSPPiYy/t40Zovf3BBHc2oemgD7VsVTFFZrU5erFFe0n52OANZZ/5sbshgD93sOh5r6I35Xmpaw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.2.0.tgz",
+      "integrity": "sha512-G4NV70B4hF9vBrUkkvNfWO6+QR4jYjeO4tc+4XrKCb4nPYj49V9Hu8Ftio7Mb0/0IlFyEOORudHrm+isY29nCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.5",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/querystring-builder": "^4.0.5",
-        "@smithy/types": "^4.3.2",
+        "@smithy/abort-controller": "^4.1.0",
+        "@smithy/protocol-http": "^5.2.0",
+        "@smithy/querystring-builder": "^4.1.0",
+        "@smithy/types": "^4.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4938,12 +5371,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.5.tgz",
-      "integrity": "sha512-R/bswf59T/n9ZgfgUICAZoWYKBHcsVDurAGX88zsiUtOTA/xUAPyiT+qkNCPwFn43pZqN84M4MiUsbSGQmgFIQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.1.0.tgz",
+      "integrity": "sha512-eksMjMHUlG5PwOUWO3k+rfLNOPVPJ70mUzyYNKb5lvyIuAwS4zpWGsxGiuT74DFWonW0xRNy+jgzGauUzX7SyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4951,12 +5384,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
-      "integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.2.0.tgz",
+      "integrity": "sha512-bwjlh5JwdOQnA01be+5UvHK4HQz4iaRKlVG46hHSJuqi0Ribt3K06Z1oQ29i35Np4G9MCDgkOGcHVyLMreMcbg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4964,13 +5397,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
-      "integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.1.0.tgz",
+      "integrity": "sha512-JqTWmVIq4AF8R8OK/2cCCiQo5ZJ0SRPsDkDgLO5/3z8xxuUp1oMIBBjfuueEe+11hGTZ6rRebzYikpKc6yQV9Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-uri-escape": "^4.0.0",
+        "@smithy/types": "^4.4.0",
+        "@smithy/util-uri-escape": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4978,12 +5411,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.5.tgz",
-      "integrity": "sha512-6SV7md2CzNG/WUeTjVe6Dj8noH32r4MnUeFKZrnVYsQxpGSIcphAanQMayi8jJLZAWm6pdM9ZXvKCpWOsIGg0w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.1.0.tgz",
+      "integrity": "sha512-VgdHhr8YTRsjOl4hnKFm7xEMOCRTnKw3FJ1nU+dlWNhdt/7eEtxtkdrJdx7PlRTabdANTmvyjE4umUl9cK4awg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4991,24 +5424,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.7.tgz",
-      "integrity": "sha512-XvRHOipqpwNhEjDf2L5gJowZEm5nsxC16pAZOeEcsygdjv9A2jdOh3YoDQvOXBGTsaJk6mNWtzWalOB9976Wlg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.1.0.tgz",
+      "integrity": "sha512-UBpNFzBNmS20jJomuYn++Y+soF8rOK9AvIGjS9yGP6uRXF5rP18h4FDUsoNpWTlSsmiJ87e2DpZo9ywzSMH7PQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2"
+        "@smithy/types": "^4.4.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.5.tgz",
-      "integrity": "sha512-YVVwehRDuehgoXdEL4r1tAAzdaDgaC9EQvhK0lEbfnbrd0bd5+CTQumbdPryX3J2shT7ZqQE+jPW4lmNBAB8JQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.1.0.tgz",
+      "integrity": "sha512-W0VMlz9yGdQ/0ZAgWICFjFHTVU0YSfGoCVpKaExRM/FDkTeP/yz8OKvjtGjs6oFokCRm0srgj/g4Cg0xuHu8Rw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5035,17 +5468,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.5.0.tgz",
-      "integrity": "sha512-ZSdE3vl0MuVbEwJBxSftm0J5nL/gw76xp5WF13zW9cN18MFuFXD5/LV0QD8P+sCU5bSWGyy6CTgUupE1HhOo1A==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.6.0.tgz",
+      "integrity": "sha512-TvlIshqx5PIi0I0AiR+PluCpJ8olVG++xbYkAIGCUkByaMUlfOXLgjQTmYbr46k4wuDe8eHiTIlUflnjK2drPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.9.0",
-        "@smithy/middleware-endpoint": "^4.1.19",
-        "@smithy/middleware-stack": "^4.0.5",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-stream": "^4.2.4",
+        "@smithy/core": "^3.10.0",
+        "@smithy/middleware-endpoint": "^4.2.0",
+        "@smithy/middleware-stack": "^4.1.0",
+        "@smithy/protocol-http": "^5.2.0",
+        "@smithy/types": "^4.4.0",
+        "@smithy/util-stream": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5053,9 +5486,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
-      "integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.4.0.tgz",
+      "integrity": "sha512-4jY91NgZz+ZnSFcVzWwngOW6VuK3gR/ihTwSU1R/0NENe9Jd8SfWgbhDCAGUWL3bI7DiDSW7XF6Ui6bBBjrqXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5065,13 +5498,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.5.tgz",
-      "integrity": "sha512-j+733Um7f1/DXjYhCbvNXABV53NyCRRA54C7bNEIxNPs0YjfRxeMKjjgm2jvTYrciZyCjsicHwQ6Q0ylo+NAUw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.1.0.tgz",
+      "integrity": "sha512-/LYEIOuO5B2u++tKr1NxNxhZTrr3A63jW8N73YTwVeUyAlbB/YM+hkftsvtKAcMt3ADYo0FsF1GY3anehffSVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.0.5",
-        "@smithy/types": "^4.3.2",
+        "@smithy/querystring-parser": "^4.1.0",
+        "@smithy/types": "^4.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5079,13 +5512,13 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
-      "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.1.0.tgz",
+      "integrity": "sha512-RUGd4wNb8GeW7xk+AY5ghGnIwM96V0l2uzvs/uVHf+tIuVX2WSvynk5CxNoBCsM2rQRSZElAo9rt3G5mJ/gktQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5093,9 +5526,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
-      "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.1.0.tgz",
+      "integrity": "sha512-V2E2Iez+bo6bUMOTENPr6eEmepdY8Hbs+Uc1vkDKgKNA/brTJqOW/ai3JO1BGj9GbCeLqw90pbbH7HFQyFotGQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5117,12 +5550,12 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
-      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.1.0.tgz",
+      "integrity": "sha512-N6yXcjfe/E+xKEccWEKzK6M+crMrlwaCepKja0pNnlSkm6SjAeLKKA++er5Ba0I17gvKfN/ThV+ZOx/CntKTVw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/is-array-buffer": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5130,9 +5563,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
-      "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.1.0.tgz",
+      "integrity": "sha512-swXz2vMjrP1ZusZWVTB/ai5gK+J8U0BWvP10v9fpcFvg+Xi/87LHvHfst2IgCs1i0v4qFZfGwCmeD/KNCdJZbQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5142,14 +5575,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.27",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.27.tgz",
-      "integrity": "sha512-i/Fu6AFT5014VJNgWxKomBJP/GB5uuOsM4iHdcmplLm8B1eAqnRItw4lT2qpdO+mf+6TFmf6dGcggGLAVMZJsQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.1.0.tgz",
+      "integrity": "sha512-D27cLtJtC4EEeERJXS+JPoogz2tE5zeE3zhWSSu6ER5/wJ5gihUxIzoarDX6K1U27IFTHit5YfHqU4Y9RSGE0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/smithy-client": "^4.5.0",
-        "@smithy/types": "^4.3.2",
+        "@smithy/property-provider": "^4.1.0",
+        "@smithy/smithy-client": "^4.6.0",
+        "@smithy/types": "^4.4.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -5158,17 +5591,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.27",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.27.tgz",
-      "integrity": "sha512-3W0qClMyxl/ELqTA39aNw1N+pN0IjpXT7lPFvZ8zTxqVFP7XCpACB9QufmN4FQtd39xbgS7/Lekn7LmDa63I5w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.1.0.tgz",
+      "integrity": "sha512-gnZo3u5dP1o87plKupg39alsbeIY1oFFnCyV2nI/++pL19vTtBLgOyftLEjPjuXmoKn2B2rskX8b7wtC/+3Okg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.1.5",
-        "@smithy/credential-provider-imds": "^4.0.7",
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/smithy-client": "^4.5.0",
-        "@smithy/types": "^4.3.2",
+        "@smithy/config-resolver": "^4.2.0",
+        "@smithy/credential-provider-imds": "^4.1.0",
+        "@smithy/node-config-provider": "^4.2.0",
+        "@smithy/property-provider": "^4.1.0",
+        "@smithy/smithy-client": "^4.6.0",
+        "@smithy/types": "^4.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5190,9 +5623,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
-      "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.1.0.tgz",
+      "integrity": "sha512-1LcueNN5GYC4tr8mo14yVYbh/Ur8jHhWOxniZXii+1+ePiIbsLZ5fEI0QQGtbRRP5mOhmooos+rLmVASGGoq5w==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5202,12 +5635,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.5.tgz",
-      "integrity": "sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.1.0.tgz",
+      "integrity": "sha512-612onNcKyxhP7/YOTKFTb2F6sPYtMRddlT5mZvYf1zduzaGzkYhpYIPxIeeEwBZFjnvEqe53Ijl2cYEfJ9d6/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5215,13 +5648,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.7.tgz",
-      "integrity": "sha512-TTO6rt0ppK70alZpkjwy+3nQlTiqNfoXja+qwuAchIEAIoSZW8Qyd76dvBv3I5bCpE38APafG23Y/u270NspiQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.1.0.tgz",
+      "integrity": "sha512-5AGoBHb207xAKSVwaUnaER+L55WFY8o2RhlafELZR3mB0J91fpL+Qn+zgRkPzns3kccGaF2vy0HmNVBMWmN6dA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.7",
-        "@smithy/types": "^4.3.2",
+        "@smithy/service-error-classification": "^4.1.0",
+        "@smithy/types": "^4.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5229,18 +5662,18 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.4.tgz",
-      "integrity": "sha512-vSKnvNZX2BXzl0U2RgCLOwWaAP9x/ddd/XobPK02pCbzRm5s55M53uwb1rl/Ts7RXZvdJZerPkA+en2FDghLuQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.3.0.tgz",
+      "integrity": "sha512-ZOYS94jksDwvsCJtppHprUhsIscRnCKGr6FXCo3SxgQ31ECbza3wqDBqSy6IsAak+h/oAXb1+UYEBmDdseAjUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.1.1",
-        "@smithy/node-http-handler": "^4.1.1",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/fetch-http-handler": "^5.2.0",
+        "@smithy/node-http-handler": "^4.2.0",
+        "@smithy/types": "^4.4.0",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-buffer-from": "^4.1.0",
+        "@smithy/util-hex-encoding": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5248,9 +5681,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
-      "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.1.0.tgz",
+      "integrity": "sha512-b0EFQkq35K5NHUYxU72JuoheM6+pytEVUGlTwiFxWFpmddA+Bpz3LgsPRIpBk8lnPE47yT7AF2Egc3jVnKLuPg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5260,12 +5693,12 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
-      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.1.0.tgz",
+      "integrity": "sha512-mEu1/UIXAdNYuBcyEPbjScKi/+MQVXNIuY/7Cm5XLIWe319kDrT5SizBE95jqtmEXoDbGoZxKLCMttdZdqTZKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5284,6 +5717,25 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@ssut/nestjs-sqs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ssut/nestjs-sqs/-/nestjs-sqs-3.0.1.tgz",
+      "integrity": "sha512-Bgf9SJgMldzTJWoScnzrCeN8mFpDVEoc16YY93+sxKiSQGFvnWk42/2QBtUY6u9cPdK2xKZtie8tLfR9wdOd3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@golevelup/nestjs-discovery": "^4.0.3",
+        "sqs-consumer": "^11.0.1",
+        "sqs-producer": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sqs": "^3.600.0",
+        "@nestjs/common": "^6.10.11 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^6.10.11 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -7330,6 +7782,78 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.1692.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1692.0.tgz",
+      "integrity": "sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/aws-sdk/node_modules/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/axios": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
@@ -7770,6 +8294,24 @@
       },
       "engines": {
         "node": ">=14.16"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -8515,6 +9057,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -9707,6 +10266,21 @@
         }
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -10217,6 +10791,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -10506,12 +11092,40 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -10554,6 +11168,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -10603,6 +11235,24 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -10613,6 +11263,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -10627,6 +11292,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -11427,6 +12098,15 @@
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "license": "MIT"
     },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/js-tiktoken": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.20.tgz",
@@ -11826,6 +12506,19 @@
         }
       }
     },
+    "node_modules/langchain/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/langsmith": {
       "version": "0.3.43",
       "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.43.tgz",
@@ -11859,6 +12552,19 @@
         "openai": {
           "optional": true
         }
+      }
+    },
+    "node_modules/langsmith/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/leven": {
@@ -13315,6 +14021,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postgres-array": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
@@ -13489,6 +14204,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/queue-microtask": {
@@ -13833,11 +14557,34 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
+      "license": "ISC"
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -13968,6 +14715,23 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {
@@ -14191,6 +14955,37 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/sqs-consumer": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/sqs-consumer/-/sqs-consumer-11.6.0.tgz",
+      "integrity": "sha512-S2rJeIs/TrH0voz2L3VsRPvDa713QWK6Bc3fXZvtip1JZj0osxNTpq4r6vYEgoCsLO5lgjW5yrb4Rt6QucuwMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sqs": "^3.723.0",
+        "debug": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sqs": "^3.723.0"
+      }
+    },
+    "node_modules/sqs-producer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/sqs-producer/-/sqs-producer-5.0.0.tgz",
+      "integrity": "sha512-xP1Vo/frpv5d20I0sC1sIUhnABFEPoHUE58ppstmjNE7HDzB33cuUdMOaZEOTtDMMje09xIcqf4ch0dFY83/cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sqs": "^3.529.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sqs": "^3.529.1"
       }
     },
     "node_modules/stack-utils": {
@@ -15382,6 +16177,35 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "license": "MIT"
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -15398,16 +16222,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -15751,6 +16575,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -15887,6 +16732,28 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,11 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.2.0",
+    "@ssut/nestjs-sqs": "^3.0.1",
     "@types/cheerio": "^0.22.35",
+    "@types/uuid": "^10.0.0",
     "@uploadthing/shared": "^7.1.10",
+    "aws-sdk": "^2.1692.0",
     "axios": "^1.11.0",
     "cheerio": "^1.1.2",
     "class-transformer": "^0.5.1",
@@ -53,7 +56,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "turndown": "^7.2.0",
-    "uploadthing": "^7.7.4"
+    "uploadthing": "^7.7.4",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/api/uploaded-files/uploaded-files.controller.ts
+++ b/src/api/uploaded-files/uploaded-files.controller.ts
@@ -12,6 +12,9 @@ import {
   UseInterceptors,
   UploadedFile,
   Req,
+  HttpCode,
+  HttpStatus,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
@@ -21,6 +24,12 @@ import { UploadedFilesService } from '../../uploaded-files/uploaded-files.servic
 // import { CreateUploadedFileDto } from './dto/create-uploaded-file.dto';
 import { UpdateUploadedFileDto } from './dto/update-uploaded-file.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+
+interface RetryAnalysisResponseDto {
+  jobUuid: string | null;
+  status: 'queued' | 'error';
+  error?: string;
+}
 
 @Controller('uploaded-files')
 export class UploadedFilesController {
@@ -104,8 +113,11 @@ export class UploadedFilesController {
   @Version('1')
   @Post(':id/analysis/retry')
   @UseGuards(JwtAuthGuard)
-  async retryAnalysis(@Req() req: any, @Param('id') id: string) {
-    const res = await this.uploadedFilesService.retryAnalysis(+id, req.user.id);
-    return res;
+  @HttpCode(HttpStatus.ACCEPTED)
+  async retryAnalysis(
+    @Req() req: any, 
+    @Param('id', ParseIntPipe) id: number
+  ): Promise<RetryAnalysisResponseDto> {
+    return await this.uploadedFilesService.retryAnalysis(id, req.user.id);
   }
 }

--- a/src/api/uploaded-files/uploaded-files.controller.ts
+++ b/src/api/uploaded-files/uploaded-files.controller.ts
@@ -100,4 +100,12 @@ export class UploadedFilesController {
     const data = await this.uploadedFilesService.getAnalysis(+id, req.user.id);
     return data;
   }
+
+  @Version('1')
+  @Post(':id/analysis/retry')
+  @UseGuards(JwtAuthGuard)
+  async retryAnalysis(@Req() req: any, @Param('id') id: string) {
+    const res = await this.uploadedFilesService.retryAnalysis(+id, req.user.id);
+    return res;
+  }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { AuthModule } from './auth/auth.module';
 import { WritingStylesModule } from './writing-styles/writing-styles.module';
 import { UploadedFilesModule } from './uploaded-files/uploaded-files.module';
 import { LibraryItemsModule } from './library-items/library-items.module';
+import { QueueModule } from './queue/queue.module';
 
 @Module({
   imports: [
@@ -29,12 +30,13 @@ import { LibraryItemsModule } from './library-items/library-items.module';
     WritingStylesModule,
     UploadedFilesModule,
     LibraryItemsModule,
+    QueueModule, // SQS 큐 모듈 추가
   ],
   controllers: [AppController],
   providers: [AppService],
 })
 export class AppModule {
   constructor() {
-    console.log('🚀 Application module initialized with OAuth authentication');
+    console.log('🚀 Application module initialized with OAuth authentication and SQS queues');
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import mikroOrmConfig from './mikro-orm.config';
@@ -36,7 +36,10 @@ import { QueueModule } from './queue/queue.module';
   providers: [AppService],
 })
 export class AppModule {
+
+  private readonly logger = new Logger(AppModule.name);
+
   constructor() {
-    console.log('🚀 Application module initialized with OAuth authentication and SQS queues');
+    this.logger.log('🚀 Application module initialized with OAuth authentication and SQS queues');
   }
 }

--- a/src/library-items/library-items.module.ts
+++ b/src/library-items/library-items.module.ts
@@ -5,20 +5,21 @@ import { Scrap } from '../scraps/entities/scrap.entity';
 import { UploadedFile } from '../uploaded-files/entities/uploaded-file.entity';
 import { Tag } from '../tags/entities/tag.entity';
 import { LibraryItemsController } from '../api/library-items/library-items.controller';
-import { ScrapsService } from '../scraps/scraps.service';
-import { UploadedFilesService } from '../uploaded-files/uploaded-files.service';
 import { User } from '../users/entities/user.entity';
 import { Article } from '../articles/entities/article.entity';
 import { AgentsModule } from '../agents/agents.module';
+import { ScrapsModule } from '../scraps/scraps.module';
+import { UploadedFilesModule } from '../uploaded-files/uploaded-files.module';
 
 @Module({
   imports: [
     MikroOrmModule.forFeature([Scrap, UploadedFile, Tag, User, Article]),
     AgentsModule,
+    ScrapsModule,
+    UploadedFilesModule,
   ],
   controllers: [LibraryItemsController],
-  providers: [LibraryItemsService, ScrapsService, UploadedFilesService],
+  providers: [LibraryItemsService],
   exports: [LibraryItemsService],
 })
 export class LibraryItemsModule {}
-

--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -14,6 +14,7 @@ import { UserOAuth } from './users/entities/user-oauth.entity';
 import { WritingStyle } from './writing-styles/entities/writing-style.entity';
 import { WritingStyleExample } from './writing-styles/entities/writing-style-example.entity';
 import { UploadedFile } from './uploaded-files/entities/uploaded-file.entity';
+import { Job } from './queue/entities/job-status.entity';
 
 export default defineConfig({
   host: process.env.DATABASE_HOST,
@@ -22,7 +23,7 @@ export default defineConfig({
   user: process.env.DATABASE_USER,
   password: process.env.DATABASE_PASSWORD,
   // 명시적으로 엔티티 지정
-  entities: [Article, ArticleArchive, Scrap, Tag, User, UserOAuth, WritingStyle, WritingStyleExample, UploadedFile],
+  entities: [Article, ArticleArchive, Scrap, Tag, User, UserOAuth, WritingStyle, WritingStyleExample, UploadedFile, Job],
   schema: 'public',
   debug: true,
   allowGlobalContext: true,

--- a/src/queue/constants/queue.constants.ts
+++ b/src/queue/constants/queue.constants.ts
@@ -1,0 +1,12 @@
+export const QUEUE_NAMES = {
+  FILE_ANALYSIS: 'TYQUILL_FILE_ANALYSIS_JOB.fifo',
+  FILE_ANALYSIS_DLQ: 'TYQUILL_FILE_ANALYSIS_JOB_DLQ.fifo',
+} as const;
+
+export const MESSAGE_TYPES = {
+  FILE_ANALYSIS_REQUEST: 'FILE_ANALYSIS_REQUEST',
+  FILE_ANALYSIS_RESPONSE: 'FILE_ANALYSIS_RESPONSE',
+} as const;
+
+export type QueueName = typeof QUEUE_NAMES[keyof typeof QUEUE_NAMES];
+export type MessageType = typeof MESSAGE_TYPES[keyof typeof MESSAGE_TYPES];

--- a/src/queue/controllers/ai-callbacks.controller.ts
+++ b/src/queue/controllers/ai-callbacks.controller.ts
@@ -1,0 +1,68 @@
+import { Body, Controller, HttpCode, HttpException, HttpStatus, Post, Req, Version } from '@nestjs/common';
+import { JobStatusService } from '../services/job-status.service';
+import { JobStatus } from '../entities/job-status.entity';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { EntityRepository } from '@mikro-orm/postgresql';
+import { UploadedFile } from '../../uploaded-files/entities/uploaded-file.entity';
+
+interface FileAnalysisCallbackBody {
+  jobUuid: string;
+  uploadedFileId: number;
+  status: 'COMPLETED' | 'FAILED';
+  markdown?: string;
+  error?: string;
+}
+
+// Note: Global prefix 'api' is already set in main.ts
+@Controller('internal/ai-callbacks')
+export class AiCallbacksController {
+  constructor(
+    private readonly jobStatusService: JobStatusService,
+    @InjectRepository(UploadedFile)
+    private readonly uploadedFileRepo: EntityRepository<UploadedFile>,
+  ) {}
+
+  private verifyAgentKey(req: any) {
+    const provided = (req.headers['x-agent-key'] || req.headers['x-tyq-signature']) as string | undefined;
+    const expected = process.env.AI_CALLBACK_SECRET;
+    if (!expected || !provided || provided !== expected) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+  }
+
+  @Version('1')
+  @Post('file-analysis')
+  @HttpCode(HttpStatus.OK)
+  async handleFileAnalysisCallback(@Req() req: any, @Body() body: FileAnalysisCallbackBody) {
+    this.verifyAgentKey(req);
+
+    const { jobUuid, uploadedFileId, status, markdown, error } = body;
+    if (!jobUuid || !uploadedFileId || !status) {
+      throw new HttpException('Invalid payload', HttpStatus.BAD_REQUEST);
+    }
+
+    if (status === 'COMPLETED') {
+      if (markdown && markdown.length > 0) {
+        const uploaded = await this.uploadedFileRepo.findOne({ uploadedFileId });
+        if (uploaded) {
+          uploaded.aiContent = markdown;
+          uploaded.updatedAt = new Date();
+          await this.uploadedFileRepo.getEntityManager().flush();
+        }
+      }
+      await this.jobStatusService.updateJobStatus(jobUuid, JobStatus.COMPLETED, {
+        result: { uploadedFileId, hasContent: !!markdown },
+      });
+      return { ok: true };
+    }
+
+    if (status === 'FAILED') {
+      await this.jobStatusService.updateJobStatus(jobUuid, JobStatus.FAILED, {
+        errorMessage: error || 'Unknown error',
+      });
+      return { ok: true };
+    }
+
+    throw new HttpException('Unsupported status', HttpStatus.BAD_REQUEST);
+  }
+}

--- a/src/queue/controllers/ai-callbacks.controller.ts
+++ b/src/queue/controllers/ai-callbacks.controller.ts
@@ -1,15 +1,31 @@
-import { Body, Controller, HttpCode, HttpException, HttpStatus, Post, Req, Version } from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpException, HttpStatus, Post, Req, Version, UsePipes, ValidationPipe } from '@nestjs/common';
 import { JobStatusService } from '../services/job-status.service';
 import { JobStatus } from '../entities/job-status.entity';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { EntityRepository } from '@mikro-orm/postgresql';
 import { UploadedFile } from '../../uploaded-files/entities/uploaded-file.entity';
+import { IsIn, IsInt, IsString, IsUUID, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
+import { Request } from 'express';
+import { timingSafeEqual } from 'node:crypto';
 
-interface FileAnalysisCallbackBody {
-  jobUuid: string;
-  uploadedFileId: number;
-  status: 'COMPLETED' | 'FAILED';
+class FileAnalysisCallbackDto {
+  @IsUUID()
+  jobUuid!: string;
+
+  @Type(() => Number)
+  @IsInt()
+  uploadedFileId!: number;
+
+  @IsIn([JobStatus.COMPLETED, JobStatus.FAILED])
+  status!: JobStatus;
+
+  @IsOptional()
+  @IsString()
   markdown?: string;
+
+  @IsOptional()
+  @IsString()
   error?: string;
 }
 
@@ -22,10 +38,17 @@ export class AiCallbacksController {
     private readonly uploadedFileRepo: EntityRepository<UploadedFile>,
   ) {}
 
-  private verifyAgentKey(req: any) {
+  private verifyAgentKey(req: Request) {
     const provided = (req.headers['x-agent-key'] || req.headers['x-tyq-signature']) as string | undefined;
     const expected = process.env.AI_CALLBACK_SECRET;
+    
     if (!expected || !provided || provided !== expected) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+    const a = Buffer.from(provided);
+    const b = Buffer.from(expected);
+    const ok = a.length === b.length && timingSafeEqual(a, b);
+    if (!ok) {
       throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
     }
   }
@@ -33,32 +56,37 @@ export class AiCallbacksController {
   @Version('1')
   @Post('file-analysis')
   @HttpCode(HttpStatus.OK)
-  async handleFileAnalysisCallback(@Req() req: any, @Body() body: FileAnalysisCallbackBody) {
+  @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
+  async handleFileAnalysisCallback(
+    @Req() req: Request, 
+    @Body() body: FileAnalysisCallbackDto
+  ): Promise<{ ok: true }> {
     this.verifyAgentKey(req);
 
     const { jobUuid, uploadedFileId, status, markdown, error } = body;
-    if (!jobUuid || !uploadedFileId || !status) {
-      throw new HttpException('Invalid payload', HttpStatus.BAD_REQUEST);
-    }
 
-    if (status === 'COMPLETED') {
-      if (markdown && markdown.length > 0) {
-        const uploaded = await this.uploadedFileRepo.findOne({ uploadedFileId });
-        if (uploaded) {
-          uploaded.aiContent = markdown;
-          uploaded.updatedAt = new Date();
-          await this.uploadedFileRepo.getEntityManager().flush();
+    if (status === JobStatus.COMPLETED) {
+      await this.uploadedFileRepo.getEntityManager().transactional(async (em) => {
+        if (markdown && markdown.length > 0) {
+          const uploaded = await em.findOne(UploadedFile, { uploadedFileId });
+          if (uploaded) {
+            uploaded.aiContent = markdown;
+            uploaded.updatedAt = new Date();
+            await em.flush();
+          }
         }
-      }
-      await this.jobStatusService.updateJobStatus(jobUuid, JobStatus.COMPLETED, {
-        result: { uploadedFileId, hasContent: !!markdown },
+        await this.jobStatusService.updateJobStatus(jobUuid, JobStatus.COMPLETED, {
+          result: { uploadedFileId, hasContent: !!markdown },
+        });
       });
       return { ok: true };
     }
 
-    if (status === 'FAILED') {
-      await this.jobStatusService.updateJobStatus(jobUuid, JobStatus.FAILED, {
-        errorMessage: error || 'Unknown error',
+    if (status === JobStatus.FAILED) {
+      await this.uploadedFileRepo.getEntityManager().transactional(async (em) => {
+        await this.jobStatusService.updateJobStatus(jobUuid, JobStatus.FAILED, {
+            errorMessage: error || 'Unknown error',
+          });
       });
       return { ok: true };
     }

--- a/src/queue/controllers/job-status.controller.ts
+++ b/src/queue/controllers/job-status.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, Get, Param, Post, Query, UseGuards, Request, Version } from '@nestjs/common';
+import { JobStatusService } from '../services/job-status.service';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { Job } from '../entities/job-status.entity';
+
+@Controller('jobs')
+@UseGuards(JwtAuthGuard)
+export class JobStatusController {
+  constructor(private readonly jobStatusService: JobStatusService) {}
+
+  @Version('1')
+  @Get('status/:jobUuid')
+  async getJobStatus(@Param('jobUuid') jobUuid: string): Promise<Job | null> {
+    return this.jobStatusService.getJobStatus(jobUuid);
+  }
+
+  @Version('1')
+  @Get('my-jobs')
+  async getMyJobs(
+    @Request() req: any,
+    @Query('limit') limit?: string,
+  ): Promise<Job[]> {
+    const limitNum = limit ? parseInt(limit, 10) : 50;
+    const userId = parseInt(req.user.id);
+    return this.jobStatusService.getJobsByUser(userId, limitNum);
+  }
+
+  @Version('1')
+  @Get('failed')
+  async getFailedJobs(@Query('limit') limit?: string): Promise<Job[]> {
+    const limitNum = limit ? parseInt(limit, 10) : 100;
+    return this.jobStatusService.getFailedJobs(limitNum);
+  }
+
+  @Version('1')
+  @Post('retry/:jobUuid')
+  async retryJob(@Param('jobUuid') jobUuid: string): Promise<{ success: boolean }> {
+    const success = await this.jobStatusService.retryJob(jobUuid);
+    return { success };
+  }
+}

--- a/src/queue/controllers/job-status.controller.ts
+++ b/src/queue/controllers/job-status.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Post, Query, UseGuards, Request, Version } from '@nestjs/common';
+import { Controller, Get, Param, Post, Query, UseGuards, Request, Version, BadRequestException } from '@nestjs/common';
 import { JobStatusService } from '../services/job-status.service';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { Job } from '../entities/job-status.entity';
@@ -21,7 +21,14 @@ export class JobStatusController {
     @Query('limit') limit?: string,
   ): Promise<Job[]> {
     const limitNum = limit ? parseInt(limit, 10) : 50;
+    if (isNaN(limitNum) || limitNum < 1 || limitNum > 1000) {
+      throw new BadRequestException('Invalid limit parameter');
+    }
+
     const userId = parseInt(req.user.id);
+    if (isNaN(userId)) {
+      throw new BadRequestException('Invalid user ID');
+    }
     return this.jobStatusService.getJobsByUser(userId, limitNum);
   }
 
@@ -29,6 +36,9 @@ export class JobStatusController {
   @Get('failed')
   async getFailedJobs(@Query('limit') limit?: string): Promise<Job[]> {
     const limitNum = limit ? parseInt(limit, 10) : 100;
+    if (isNaN(limitNum) || limitNum < 1 || limitNum > 1000) {
+      throw new BadRequestException('Invalid limit parameter');
+    }
     return this.jobStatusService.getFailedJobs(limitNum);
   }
 

--- a/src/queue/dto/file-analysis.dto.ts
+++ b/src/queue/dto/file-analysis.dto.ts
@@ -1,3 +1,5 @@
+import { IsNumber, IsUrl, IsString, IsMimeType, IsDateString } from "class-validator";
+
 export interface FileAnalysisMessage {
   uploadedFileId: number;
   fileUrl: string;
@@ -16,11 +18,22 @@ export interface FileAnalysisResponse {
 }
 
 export class FileAnalysisRequestDto {
+  @IsNumber()
   uploadedFileId: number;
+
+  @IsUrl()
   fileUrl: string;
+
+  @IsString()
   fileName: string;
+  
+  @IsMimeType()
   mimeType: string;
+
+  @IsNumber()
   userId: number;
+
+  @IsDateString()
   timestamp: string;
 
   constructor(data: FileAnalysisMessage) {

--- a/src/queue/dto/file-analysis.dto.ts
+++ b/src/queue/dto/file-analysis.dto.ts
@@ -1,0 +1,34 @@
+export interface FileAnalysisMessage {
+  uploadedFileId: number;
+  fileUrl: string;
+  fileName: string;
+  mimeType: string;
+  userId: number;
+  timestamp: string;
+}
+
+export interface FileAnalysisResponse {
+  uploadedFileId: number;
+  analysisResult: string;
+  success: boolean;
+  error?: string;
+  timestamp: string;
+}
+
+export class FileAnalysisRequestDto {
+  uploadedFileId: number;
+  fileUrl: string;
+  fileName: string;
+  mimeType: string;
+  userId: number;
+  timestamp: string;
+
+  constructor(data: FileAnalysisMessage) {
+    this.uploadedFileId = data.uploadedFileId;
+    this.fileUrl = data.fileUrl;
+    this.fileName = data.fileName;
+    this.mimeType = data.mimeType;
+    this.userId = data.userId;
+    this.timestamp = data.timestamp;
+  }
+}

--- a/src/queue/entities/job-status.entity.ts
+++ b/src/queue/entities/job-status.entity.ts
@@ -38,11 +38,11 @@ export class Job {
   @Property({ nullable: true })
   errorMessage?: string;
 
-  @Property({ nullable: true })
-  retryCount?: number = 0;
+  @Property()
+  retryCount: number = 0;
 
-  @Property({ nullable: true })
-  maxRetries?: number = 3;
+  @Property()
+  maxRetries: number = 3;
 
   @Property({ nullable: true })
   sqsMessageId?: string;

--- a/src/queue/entities/job-status.entity.ts
+++ b/src/queue/entities/job-status.entity.ts
@@ -1,0 +1,64 @@
+import { Entity, PrimaryKey, Property, Enum } from '@mikro-orm/core';
+
+export enum JobType {
+  FILE_ANALYSIS = 'FILE_ANALYSIS',
+}
+
+export enum JobStatus {
+  PENDING = 'PENDING',
+  PROCESSING = 'PROCESSING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+  RETRYING = 'RETRYING',
+}
+
+@Entity({ tableName: 'jobs' })
+export class Job {
+  @PrimaryKey()
+  jobId!: number;
+
+  @Property()
+  jobUuid!: string; // Unique identifier for tracking
+
+  @Enum(() => JobType)
+  jobType!: JobType;
+
+  @Enum(() => JobStatus)
+  status: JobStatus = JobStatus.PENDING;
+
+  @Property()
+  userId!: number;
+
+  @Property({ type: 'json', nullable: true })
+  payload?: any; // Job-specific data
+
+  @Property({ type: 'json', nullable: true })
+  result?: any; // Job result
+
+  @Property({ nullable: true })
+  errorMessage?: string;
+
+  @Property({ nullable: true })
+  retryCount?: number = 0;
+
+  @Property({ nullable: true })
+  maxRetries?: number = 3;
+
+  @Property({ nullable: true })
+  sqsMessageId?: string;
+
+  @Property({ nullable: true })
+  queueName?: string;
+
+  @Property()
+  createdAt: Date = new Date();
+
+  @Property({ onUpdate: () => new Date() })
+  updatedAt: Date = new Date();
+
+  @Property({ nullable: true })
+  startedAt?: Date;
+
+  @Property({ nullable: true })
+  completedAt?: Date;
+}

--- a/src/queue/queue.module.ts
+++ b/src/queue/queue.module.ts
@@ -17,11 +17,15 @@ import { UploadedFile } from '../uploaded-files/entities/uploaded-file.entity';
     SqsModule.registerAsync({
       imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => {
+        const queueUrl = configService.get<string>('AWS_SQS_FILE_ANALYSIS_QUEUE_URL')!;
+        if (!queueUrl) {
+          throw new Error('AWS_SQS_FILE_ANALYSIS_QUEUE_URL is not set');
+        }
         return {
           producers: [
             {
               name: QUEUE_NAMES.FILE_ANALYSIS,
-              queueUrl: configService.get<string>('AWS_SQS_FILE_ANALYSIS_QUEUE_URL')!,
+              queueUrl: queueUrl,
               region: configService.get<string>('AWS_REGION') || 'us-east-1',
             },
           ],

--- a/src/queue/queue.module.ts
+++ b/src/queue/queue.module.ts
@@ -1,0 +1,40 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { SqsModule } from '@ssut/nestjs-sqs';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { FileAnalysisProducerService } from './services/file-analysis-producer.service';
+import { JobStatusService } from './services/job-status.service';
+import { JobStatusController } from './controllers/job-status.controller';
+import { AiCallbacksController } from './controllers/ai-callbacks.controller';
+import { QUEUE_NAMES } from './constants/queue.constants';
+import { Job } from './entities/job-status.entity';
+import { UploadedFile } from '../uploaded-files/entities/uploaded-file.entity';
+
+@Module({
+  imports: [
+    ConfigModule,
+    MikroOrmModule.forFeature([Job, UploadedFile]),
+    SqsModule.registerAsync({
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService) => {
+        return {
+          producers: [
+            {
+              name: QUEUE_NAMES.FILE_ANALYSIS,
+              queueUrl: configService.get<string>('AWS_SQS_FILE_ANALYSIS_QUEUE_URL')!,
+              region: configService.get<string>('AWS_REGION') || 'us-east-1',
+            },
+          ],
+        };
+      },
+      inject: [ConfigService],
+    }),
+  ],
+  controllers: [JobStatusController, AiCallbacksController],
+  providers: [
+    FileAnalysisProducerService,
+    JobStatusService,
+  ],
+  exports: [FileAnalysisProducerService, JobStatusService],
+})
+export class QueueModule {}

--- a/src/queue/services/file-analysis-producer.service.ts
+++ b/src/queue/services/file-analysis-producer.service.ts
@@ -1,0 +1,83 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SqsService } from '@ssut/nestjs-sqs';
+import { FileAnalysisMessage, FileAnalysisRequestDto } from '../dto/file-analysis.dto';
+import { QUEUE_NAMES, MESSAGE_TYPES } from '../constants/queue.constants';
+import { JobStatusService } from './job-status.service';
+import { JobType, JobStatus } from '../entities/job-status.entity';
+
+@Injectable()
+export class FileAnalysisProducerService {
+  private readonly logger = new Logger(FileAnalysisProducerService.name);
+
+  constructor(
+    private readonly sqsService: SqsService,
+    private readonly jobStatusService: JobStatusService,
+  ) {}
+
+  async sendFileAnalysisRequest(data: FileAnalysisMessage): Promise<string> {
+    try {
+      const message = new FileAnalysisRequestDto(data);
+      
+      // Create job tracking record
+      const job = await this.jobStatusService.createJob({
+        jobType: JobType.FILE_ANALYSIS,
+        userId: data.userId,
+        payload: {
+          uploadedFileId: data.uploadedFileId,
+          fileUrl: data.fileUrl,
+          fileName: data.fileName,
+          mimeType: data.mimeType,
+        },
+        queueName: QUEUE_NAMES.FILE_ANALYSIS,
+      });
+      
+      this.logger.log(`📤 Sending file analysis request to queue for file: ${data.fileName}`);
+      
+      const result = await this.sqsService.send(QUEUE_NAMES.FILE_ANALYSIS, {
+        id: `file-analysis-${data.uploadedFileId}-${Date.now()}`,
+        body: {
+          type: MESSAGE_TYPES.FILE_ANALYSIS_REQUEST,
+          jobUuid: job.jobUuid,
+          data: message,
+        },
+        messageAttributes: {
+          messageType: {
+            StringValue: MESSAGE_TYPES.FILE_ANALYSIS_REQUEST,
+            DataType: 'String',
+          },
+          jobUuid: {
+            StringValue: job.jobUuid,
+            DataType: 'String',
+          },
+          uploadedFileId: {
+            StringValue: data.uploadedFileId.toString(),
+            DataType: 'String',
+          },
+          userId: {
+            StringValue: data.userId.toString(),
+            DataType: 'String',
+          },
+        },
+        groupId: `file-analysis-${data.userId}`, // For FIFO queue
+        deduplicationId: `${job.jobUuid}-${Date.now()}`, // For FIFO queue
+      });
+
+      // Update job with actual SQS MessageId if available
+      try {
+        const batchResults = Array.isArray(result) ? result : [];
+        const messageId = batchResults.length > 0 ? batchResults[0].MessageId : undefined;
+        await this.jobStatusService.updateJobStatus(job.jobUuid, JobStatus.PENDING, {
+          sqsMessageId: messageId || 'sent-to-queue',
+        });
+      } catch (e) {
+        this.logger.warn(`⚠️ Unable to record SQS MessageId for Job ${job.jobUuid}: ${e}`);
+      }
+
+      this.logger.log(`✅ File analysis request sent successfully for file: ${data.fileName} (Job: ${job.jobUuid})`);
+      return job.jobUuid;
+    } catch (error) {
+      this.logger.error(`❌ Failed to send file analysis request for file: ${data.fileName}`, error);
+      throw error;
+    }
+  }
+}

--- a/src/queue/services/job-status.service.ts
+++ b/src/queue/services/job-status.service.ts
@@ -1,0 +1,113 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EntityManager } from '@mikro-orm/postgresql';
+import { Job, JobType, JobStatus } from '../entities/job-status.entity';
+import { v4 as uuidv4 } from 'uuid';
+
+@Injectable()
+export class JobStatusService {
+  private readonly logger = new Logger(JobStatusService.name);
+
+  constructor(private readonly em: EntityManager) {}
+
+  async createJob(data: {
+    jobType: JobType;
+    userId: number;
+    payload?: any;
+    queueName?: string;
+    maxRetries?: number;
+  }): Promise<Job> {
+    const job = new Job();
+    job.jobUuid = uuidv4();
+    job.jobType = data.jobType;
+    job.userId = data.userId;
+    job.payload = data.payload;
+    job.queueName = data.queueName;
+    job.maxRetries = data.maxRetries || 3;
+    job.status = JobStatus.PENDING;
+
+    await this.em.persistAndFlush(job);
+    
+    this.logger.log(`📝 Created job: ${job.jobUuid} (${job.jobType})`);
+    return job;
+  }
+
+  async updateJobStatus(jobUuid: string, status: JobStatus, data?: {
+    result?: any;
+    errorMessage?: string;
+    sqsMessageId?: string;
+    retryCount?: number;
+  }): Promise<Job | null> {
+    const job = await this.em.findOne(Job, { jobUuid });
+    
+    if (!job) {
+      this.logger.warn(`⚠️ Job not found: ${jobUuid}`);
+      return null;
+    }
+
+    job.status = status;
+    
+    if (data) {
+      if (data.result !== undefined) job.result = data.result;
+      if (data.errorMessage !== undefined) job.errorMessage = data.errorMessage;
+      if (data.sqsMessageId !== undefined) job.sqsMessageId = data.sqsMessageId;
+      if (data.retryCount !== undefined) job.retryCount = data.retryCount;
+    }
+
+    // Update timestamps based on status
+    switch (status) {
+      case JobStatus.PROCESSING:
+        job.startedAt = new Date();
+        break;
+      case JobStatus.COMPLETED:
+      case JobStatus.FAILED:
+        job.completedAt = new Date();
+        break;
+    }
+
+    await this.em.flush();
+    
+    this.logger.log(`📊 Updated job ${jobUuid} status to: ${status}`);
+    return job;
+  }
+
+  async getJobStatus(jobUuid: string): Promise<Job | null> {
+    return this.em.findOne(Job, { jobUuid });
+  }
+
+  async getJobsByUser(userId: number, limit: number = 50): Promise<Job[]> {
+    return this.em.find(Job, { userId }, {
+      orderBy: { createdAt: 'DESC' },
+      limit,
+    });
+  }
+
+  async getFailedJobs(limit: number = 100): Promise<Job[]> {
+    return this.em.find(Job, { status: JobStatus.FAILED }, {
+      orderBy: { createdAt: 'DESC' },
+      limit,
+    });
+  }
+
+  async retryJob(jobUuid: string): Promise<boolean> {
+    const job = await this.em.findOne(Job, { jobUuid });
+    
+    if (!job || job.status !== JobStatus.FAILED) {
+      this.logger.warn(`⚠️ Cannot retry job: ${jobUuid} (not found or not failed)`);
+      return false;
+    }
+
+    if ((job.retryCount || 0) >= (job.maxRetries || 3)) {
+      this.logger.warn(`⚠️ Job ${jobUuid} has exceeded max retries`);
+      return false;
+    }
+
+    job.status = JobStatus.RETRYING;
+    job.retryCount = (job.retryCount || 0) + 1;
+    job.errorMessage = undefined;
+
+    await this.em.flush();
+    
+    this.logger.log(`🔄 Retrying job: ${jobUuid} (attempt ${job.retryCount})`);
+    return true;
+  }
+}

--- a/src/queue/services/job-status.service.ts
+++ b/src/queue/services/job-status.service.ts
@@ -22,7 +22,7 @@ export class JobStatusService {
     job.userId = data.userId;
     job.payload = data.payload;
     job.queueName = data.queueName;
-    job.maxRetries = data.maxRetries || 3;
+    job.maxRetries = data.maxRetries ?? 3;
     job.status = JobStatus.PENDING;
 
     await this.em.persistAndFlush(job);
@@ -44,6 +44,29 @@ export class JobStatusService {
       return null;
     }
 
+    const currentStatus = job.status;
+    
+    // Check if the transition is valid
+    if (!this.isValidTransition(currentStatus, status)) {
+      this.logger.warn(`⚠️ Invalid status transition for job ${jobUuid}: ${currentStatus} -> ${status}. No changes applied.`);
+      return job;
+    }
+
+    // Handle idempotent case (same status)
+    if (currentStatus === status) {
+      this.logger.debug(`🔄 Idempotent status update for job ${jobUuid}: ${status} (no change)`);
+      // Still apply data updates for idempotent case (e.g., updating result or error message)
+      if (data) {
+        if (data.result !== undefined) job.result = data.result;
+        if (data.errorMessage !== undefined) job.errorMessage = data.errorMessage;
+        if (data.sqsMessageId !== undefined) job.sqsMessageId = data.sqsMessageId;
+        if (data.retryCount !== undefined) job.retryCount = data.retryCount;
+      }
+      await this.em.flush();
+      return job;
+    }
+
+    // Apply status change and related updates
     job.status = status;
     
     if (data) {
@@ -53,20 +76,17 @@ export class JobStatusService {
       if (data.retryCount !== undefined) job.retryCount = data.retryCount;
     }
 
-    // Update timestamps based on status
-    switch (status) {
-      case JobStatus.PROCESSING:
-        job.startedAt = new Date();
-        break;
-      case JobStatus.COMPLETED:
-      case JobStatus.FAILED:
-        job.completedAt = new Date();
-        break;
+    // Update timestamps only for specific transitions
+    if ((currentStatus === JobStatus.PENDING || currentStatus === JobStatus.RETRYING) && status === JobStatus.PROCESSING) {
+      job.startedAt = new Date();
+    }
+    if (currentStatus === JobStatus.PROCESSING && (status === JobStatus.COMPLETED || status === JobStatus.FAILED)) {
+      job.completedAt = new Date();
     }
 
     await this.em.flush();
     
-    this.logger.log(`📊 Updated job ${jobUuid} status to: ${status}`);
+    this.logger.log(`📊 Updated job ${jobUuid} status: ${currentStatus} -> ${status}`);
     return job;
   }
 
@@ -96,18 +116,45 @@ export class JobStatusService {
       return false;
     }
 
-    if ((job.retryCount || 0) >= (job.maxRetries || 3)) {
+    if ((job.retryCount ?? 0) >= (job.maxRetries ?? 3)) {
       this.logger.warn(`⚠️ Job ${jobUuid} has exceeded max retries`);
       return false;
     }
 
     job.status = JobStatus.RETRYING;
-    job.retryCount = (job.retryCount || 0) + 1;
+    job.retryCount = (job.retryCount ?? 0) + 1;
     job.errorMessage = undefined;
 
     await this.em.flush();
     
     this.logger.log(`🔄 Retrying job: ${jobUuid} (attempt ${job.retryCount})`);
     return true;
+  }
+
+  /**
+   * Validates if a status transition is allowed based on the current and next status.
+   * Implements state machine rules for job status transitions.
+   * 
+   * @param current - Current job status
+   * @param next - Requested next status
+   * @returns true if transition is valid, false otherwise
+   */
+  private isValidTransition(current: JobStatus, next: JobStatus): boolean {
+    // Same status transitions are always valid (idempotent)
+    if (current === next) {
+      return true;
+    }
+
+    // Define allowed transitions based on state machine rules
+    const allowedTransitions: Record<JobStatus, JobStatus[]> = {
+      [JobStatus.PENDING]: [JobStatus.PROCESSING, JobStatus.FAILED],
+      [JobStatus.PROCESSING]: [JobStatus.COMPLETED, JobStatus.FAILED],
+      [JobStatus.RETRYING]: [JobStatus.PROCESSING, JobStatus.FAILED],
+      [JobStatus.COMPLETED]: [], // No transitions allowed from completed state
+      [JobStatus.FAILED]: [JobStatus.RETRYING], // Only retrying is allowed from failed state
+    };
+
+    const validNextStates = allowedTransitions[current] || [];
+    return validNextStates.includes(next);
   }
 }

--- a/src/uploaded-files/entities/uploaded-file.entity.ts
+++ b/src/uploaded-files/entities/uploaded-file.entity.ts
@@ -28,10 +28,10 @@ export class UploadedFile {
   @Property({ name: 'ai_content', type: 'text', nullable: true })
   aiContent?: string;
 
-  @Property({ name: 'created_at' })
+  @Property({ name: 'created_at', onCreate: () => new Date(), defaultRaw: 'now()' })
   createdAt: Date = new Date();
 
-  @Property({ name: 'updated_at', onUpdate: () => new Date() })
+  @Property({ name: 'updated_at', onUpdate: () => new Date(), defaultRaw: 'now()' })
   updatedAt: Date = new Date();
 
   @ManyToOne(() => User, { fieldName: 'user_id' })

--- a/src/uploaded-files/entities/uploaded-file.entity.ts
+++ b/src/uploaded-files/entities/uploaded-file.entity.ts
@@ -31,6 +31,9 @@ export class UploadedFile {
   @Property({ name: 'created_at' })
   createdAt: Date = new Date();
 
+  @Property({ name: 'updated_at', onUpdate: () => new Date() })
+  updatedAt: Date = new Date();
+
   @ManyToOne(() => User, { fieldName: 'user_id' })
   user: User;
 

--- a/src/uploaded-files/uploaded-files.module.ts
+++ b/src/uploaded-files/uploaded-files.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { UploadedFilesService } from './uploaded-files.service';
 import { UploadedFilesController } from '../api/uploaded-files/uploaded-files.controller';
@@ -6,12 +6,14 @@ import { UploadedFile } from './entities/uploaded-file.entity';
 import { User } from '../users/entities/user.entity';
 import { AuthModule } from '../auth/auth.module';
 import { AgentsModule } from '../agents/agents.module';
+import { QueueModule } from '../queue/queue.module';
 
 @Module({
   imports: [
     MikroOrmModule.forFeature([UploadedFile, User]),
     AuthModule,
     AgentsModule,
+    forwardRef(() => QueueModule), // Use forwardRef to avoid circular dependency
   ],
   controllers: [UploadedFilesController],
   providers: [UploadedFilesService],

--- a/src/uploaded-files/uploaded-files.service.ts
+++ b/src/uploaded-files/uploaded-files.service.ts
@@ -7,7 +7,10 @@ import { UploadedFile } from './entities/uploaded-file.entity';
 import { User } from '../users/entities/user.entity';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import * as fs from 'fs';
-import { FileAnalysisAgentService } from '../agents/services/file-analysis-agent.service';
+import { FileAnalysisProducerService } from '../queue/services/file-analysis-producer.service';
+import { FileAnalysisMessage } from '../queue/dto/file-analysis.dto';
+import { JobStatusService } from '../queue/services/job-status.service';
+import { JobStatus } from '../queue/entities/job-status.entity';
 @Injectable()
 export class UploadedFilesService {
   private readonly logger = new Logger(UploadedFilesService.name);
@@ -21,7 +24,8 @@ export class UploadedFilesService {
     private readonly uploadedFileRepository: EntityRepository<UploadedFile>,
     @InjectRepository(User)
     private readonly userRepository: EntityRepository<User>,
-    private readonly fileAnalysisAgentService: FileAnalysisAgentService,
+    private readonly fileAnalysisProducerService: FileAnalysisProducerService,
+    private readonly jobStatusService: JobStatusService,
   ) {
     this.bucket = process.env.AWS_S3_BUCKET || '';
     if (this.bucket === '') {
@@ -94,11 +98,31 @@ export class UploadedFilesService {
     await this.em.removeAndFlush(uploadedFile);
   }
 
-  async getAnalysis(id: number, userId: number): Promise<{ markdown: string | null; updatedAt?: Date }> {
+  async getAnalysis(id: number, userId: number): Promise<{ markdown: string | null; updatedAt?: Date; status?: JobStatus; jobUuid?: string; error?: string }> {
     const uploaded = await this.findOne(id, userId);
-    return { 
-      markdown: uploaded.aiContent ?? null, 
-      updatedAt: uploaded.createdAt,
+
+    // Find the latest job for this uploaded file from recent jobs
+    let jobUuid: string | undefined;
+    let status: JobStatus | undefined;
+    let error: string | undefined;
+    try {
+      const jobs = await this.jobStatusService.getJobsByUser(userId, 50);
+      const latest = jobs.find(j => (j.payload && j.payload.uploadedFileId === id));
+      if (latest) {
+        jobUuid = latest.jobUuid;
+        status = latest.status as JobStatus;
+        error = latest.errorMessage ?? undefined;
+      }
+    } catch (e) {
+      // ignore job lookup failures; return content only
+    }
+
+    return {
+      markdown: uploaded.aiContent ?? null,
+      updatedAt: uploaded.updatedAt ?? uploaded.createdAt,
+      status,
+      jobUuid,
+      error,
     };
   }
 
@@ -147,9 +171,9 @@ export class UploadedFilesService {
         fileSize: file.size,
       });
 
-      // PDF 또는 문서 파일인 경우 AI 분석 수행
+      // PDF 또는 문서 파일인 경우 AI 분석을 큐에 요청
       if (this.shouldAnalyzeFile(file.mimetype)) {
-        this.analyzeFileInBackground(uploadedFile, fileUrl);
+        await this.queueFileAnalysis(uploadedFile, fileUrl);
       }
 
       // 임시 파일 정리
@@ -196,22 +220,33 @@ export class UploadedFilesService {
     return this.ANALYZABLE_MIME_TYPES.has(mimeType as any);
   }
 
-  private async analyzeFileInBackground(uploadedFile: UploadedFile, fileUrl: string): Promise<void> {
+  private async queueFileAnalysis(uploadedFile: UploadedFile, fileUrl: string): Promise<string | null> {
     try {
-      this.logger.log(`🔍 Starting AI analysis for file: ${uploadedFile.fileName}`);
+      this.logger.log(`📤 Queuing AI analysis for file: ${uploadedFile.fileName}`);
 
-      const analysisResult = await this.fileAnalysisAgentService.analyzeFile(
-        fileUrl
-      );
+      const analysisMessage: FileAnalysisMessage = {
+        uploadedFileId: uploadedFile.uploadedFileId,
+        fileUrl: fileUrl,
+        fileName: uploadedFile.fileName,
+        mimeType: uploadedFile.mimeType,
+        userId: uploadedFile.user.userId,
+        timestamp: new Date().toISOString(),
+      };
 
-      // Update the uploaded file with AI analysis
-      uploadedFile.aiContent = analysisResult;
-      await this.em.flush();
+      const jobUuid = await this.fileAnalysisProducerService.sendFileAnalysisRequest(analysisMessage);
 
-      this.logger.log(`✅ AI analysis completed for file: ${uploadedFile.fileName}`);
+      this.logger.log(`✅ AI analysis queued for file: ${uploadedFile.fileName} (Job: ${jobUuid})`);
+      return jobUuid;
     } catch (error) {
-      this.logger.error(`❌ Failed to analyze file ${uploadedFile.fileName}:`, error);
-      // Don't throw - let the file upload succeed even if analysis fails
+      this.logger.error(`❌ Failed to queue analysis for file ${uploadedFile.fileName}:`, error);
+      // Don't throw - let the file upload succeed even if queueing fails
+      return null;
     }
+  }
+
+  async retryAnalysis(id: number, userId: number): Promise<{ jobUuid: string | null; status: 'queued' | 'error' }> {
+    const uploaded = await this.findOne(id, userId);
+    const jobUuid = await this.queueFileAnalysis(uploaded, uploaded.filePath);
+    return { jobUuid, status: jobUuid ? 'queued' : 'error' };
   }
 }


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-307](https://linear.app/chill-mato/issue/CHI-307/)

## 📋 변경사항 요약
- SQS 프로듀서 도입 및 큐 설정
  - `QueueModule` 추가, `@ssut/nestjs-sqs` 기반 SQS Producer 등록
- 업로드 → 비동기 분석 큐로 전환
  - 업로드 성공 시 SQS에 분석 작업 전송(동기 분석 제거)
- AI 분석 콜백 엔드포인트 추가
  - `POST /api/v1/internal/ai-callbacks/file-analysis` (x-agent-key 인증)
  - 분석 완료 시 `uploaded_files.ai_content` 갱신, Job 상태 COMPLETED/FAILED 반영
- 분석 상태 노출 + 재시도 API
  - `GET /api/v1/uploaded-files/:id/analysis` 응답에 `status, jobUuid, error` 포함
  - `POST /api/v1/uploaded-files/:id/analysis/retry` 추가(실패 시 재분석 큐잉)
- Job 트래킹 도입
  - Job 엔티티/서비스/상태 API 등록, MikroORM에 엔티티 등록
- SQS MessageId 저장
  - 큐 전송 결과의 실제 `MessageId`를 Job에 기록

## 🗃️ 데이터베이스 변경사항
- 테이블 추가: `jobs`

## 📦 빌드 & 배포
- 환경 변수
  - `AWS_SQS_FILE_ANALYSIS_QUEUE_URL` (FIFO 큐 URL)
  - `AWS_REGION`
  - `AI_CALLBACK_SECRET` (Agent 콜백 인증용)

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음
