### PR TITLE
[CHI-314] 초안 생성 시 PDF 을 참고자료로 생성 기능 추가

### DIFF
--- a/src/agents/services/newsletter-agent.service.ts
+++ b/src/agents/services/newsletter-agent.service.ts
@@ -17,6 +17,11 @@ interface NewsletterInput {
   readonly generationParams?: string;
   readonly articleStructureTemplate?: any[];
   readonly writingStyleExampleContents?: string[];
+  readonly pdfUrlsWithPrompts?: Array<{
+    url: string;
+    usagePrompt: string;
+    aiContent?: string;
+  }>;
 }
 
 interface NewsletterOutput {
@@ -51,6 +56,7 @@ export class NewsletterAgentService {
       this.logger.log(`📝 Topic: ${input.topic}`);
       this.logger.log(`💡 Key insight: ${input.keyInsight || 'None'}`);
       this.logger.log(`📊 Scraps count: ${input.scrapsWithComments?.length || 0}`);
+      this.logger.log(`📄 PDF files count: ${input.pdfUrlsWithPrompts?.length || 0}`);
 
       const response = await fetch(`${this.agentApiUrl}/api/v1/newsletter/generate`, {
         method: 'POST',

--- a/src/api/articles/articles.controller.ts
+++ b/src/api/articles/articles.controller.ts
@@ -15,6 +15,7 @@ import { ArticlesService } from '../../articles/articles.service';
 import { CreateArticleDto } from './dto/create-article.dto';
 import { GenerateArticleDto, GenerateArticleResponse } from './dto/generate-article.dto';
 import { GenerateArticleV2Dto, GenerateArticleV2Response, ArticleStatusV2Response } from './dto/generate-article-v2.dto';
+import { GenerateArticleV3Dto } from './dto/generate-article-v3.dto';
 import { UpdateArticleDto } from './dto/update-article.dto';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
@@ -192,5 +193,56 @@ export class ArticlesController {
   findAllV2(@Request() req: any) {
     const userId = parseInt(req.user.id);
     return this.articlesService.findByUserV2(userId);
+  }
+
+  // ========== V3 API (PDF 지원) ==========
+
+  /**
+   * V3: AI를 사용하여 뉴스레터를 비동기로 생성합니다 (PDF 지원)
+   * POST /api/v3/articles/generate
+   */
+  @ApiOperation({ 
+    summary: 'V3: AI를 사용하여 뉴스레터를 비동기로 생성합니다 (PDF 지원)',
+    description: '스크랩과 PDF 업로드를 모두 지원하며, 각각에 대한 사용 프롬프트를 받아 처리합니다.'
+  })
+  @ApiResponse({ status: 202, description: '뉴스레터 생성이 시작되었습니다.', type: GenerateArticleV2Response })
+  @ApiResponse({ status: 400, description: '잘못된 요청입니다.' })
+  @ApiResponse({ status: 404, description: '사용자나 리소스를 찾을 수 없습니다.' })
+  @Version('3')
+  @Post('generate')
+  async generateArticleV3(@Request() req: any, @Body() generateArticleDto: GenerateArticleV3Dto): Promise<GenerateArticleV2Response> {
+    const userId = parseInt(req.user.id);
+    return this.articlesService.generateArticleV3(userId, generateArticleDto);
+  }
+
+  /**
+   * V3: 아티클 생성 상태 확인
+   * GET /api/v3/articles/:id/status
+   */
+  @ApiOperation({ 
+    summary: 'V3: 아티클 생성 상태를 확인합니다',
+    description: 'PDF 처리 진행률을 포함한 상세 상태 정보를 제공합니다.'
+  })
+  @ApiResponse({ status: 200, description: '아티클 상태 정보', type: ArticleStatusV2Response })
+  @ApiResponse({ status: 404, description: '아티클을 찾을 수 없습니다.' })
+  @Version('3')
+  @Get(':id/status')
+  async getArticleStatusV3(@Param('id') id: string): Promise<ArticleStatusV2Response> {
+    return this.articlesService.getArticleStatusV3(+id);
+  }
+
+  /**
+   * V3: 현재 사용자의 아티클 조회 (PDF 정보 포함)
+   * GET /api/v3/articles
+   */
+  @ApiOperation({ 
+    summary: 'V3: 현재 사용자의 아티클 목록을 조회합니다',
+    description: 'PDF 참고 자료 정보가 포함된 아티클 목록을 반환합니다.'
+  })
+  @Version('3')
+  @Get()
+  findAllV3(@Request() req: any) {
+    const userId = parseInt(req.user.id);
+    return this.articlesService.findByUserV3(userId);
   }
 }

--- a/src/api/articles/dto/generate-article-v3.dto.ts
+++ b/src/api/articles/dto/generate-article-v3.dto.ts
@@ -1,0 +1,62 @@
+import { IsString, IsOptional, IsArray, ValidateNested, IsNumber } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ScrapWithCommentDto {
+  @ApiProperty({ description: '스크랩 ID' })
+  @IsNumber()
+  scrapId: number;
+
+  @ApiPropertyOptional({ description: '사용자 코멘트' })
+  @IsOptional()
+  @IsString()
+  userComment?: string;
+}
+
+export class UploadWithUsagePromptDto {
+  @ApiProperty({ description: '업로드된 파일 ID' })
+  @IsNumber()
+  uploadedFileId: number;
+
+  @ApiProperty({ description: '사용 프롬프트 (어떻게 활용할지)', maxLength: 75 })
+  @IsString()
+  usagePrompt: string;
+}
+
+export class GenerateArticleV3Dto {
+  @ApiProperty({ description: '아티클 주제' })
+  @IsString()
+  topic: string;
+
+  @ApiProperty({ description: '키 인사이트/메시지' })
+  @IsString()
+  keyInsight: string;
+
+  @ApiPropertyOptional({ description: '스크랩과 코멘트 목록' })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ScrapWithCommentDto)
+  scrapWithOptionalComment?: ScrapWithCommentDto[];
+
+  @ApiPropertyOptional({ description: '업로드된 PDF 파일과 사용 프롬프트 목록' })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UploadWithUsagePromptDto)
+  uploadWithUsagePrompt?: UploadWithUsagePromptDto[];
+
+  @ApiPropertyOptional({ description: '생성 파라미터 (추가 지시사항)' })
+  @IsOptional()
+  @IsString()
+  generationParams?: string;
+
+  @ApiPropertyOptional({ description: '아티클 구조 템플릿' })
+  @IsOptional()
+  articleStructureTemplate?: any[];
+
+  @ApiPropertyOptional({ description: '문체 스타일 ID' })
+  @IsOptional()
+  @IsNumber()
+  writingStyleId?: number;
+}

--- a/src/api/uploaded-files/uploaded-files.controller.ts
+++ b/src/api/uploaded-files/uploaded-files.controller.ts
@@ -46,7 +46,7 @@ export class UploadedFilesController {
         cb(null, `${Date.now()}-${safe}`);
       },
     }),
-    limits: { fileSize: 50 * 1024 * 1024 }, // 50MB limit (adjust as needed)
+    limits: { fileSize: 30 * 1024 * 1024 }, // 30MB limit (adjust as needed)
     fileFilter: (req, file, cb) => {
       if (file.mimetype !== 'application/pdf') {
         return cb(null, false);

--- a/src/articles/articles.module.ts
+++ b/src/articles/articles.module.ts
@@ -8,10 +8,11 @@ import { ArticleArchive } from '../article-archive/entities/article-archive.enti
 import { Scrap } from '../scraps/entities/scrap.entity';
 import { User } from '../users/entities/user.entity';
 import { WritingStyleExample } from 'src/writing-styles/entities/writing-style-example.entity';
+import { UploadedFile } from '../uploaded-files/entities/uploaded-file.entity';
 
 @Module({
   imports: [
-    MikroOrmModule.forFeature([Article, ArticleArchive, Scrap, User, WritingStyleExample]),
+    MikroOrmModule.forFeature([Article, ArticleArchive, Scrap, User, WritingStyleExample, UploadedFile]),
     AgentsModule,
   ],
   controllers: [ArticlesController],

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -10,6 +10,9 @@ import {
   GenerateArticleV2Response,
   ArticleStatusV2Response,
 } from '../api/articles/dto/generate-article-v2.dto';
+import {
+  GenerateArticleV3Dto,
+} from '../api/articles/dto/generate-article-v3.dto';
 import { UpdateArticleDto } from '../api/articles/dto/update-article.dto';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { Article } from './entities/article.entity';
@@ -19,6 +22,7 @@ import { User } from '../users/entities/user.entity';
 import { EntityManager, EntityRepository } from '@mikro-orm/core';
 import { NewsletterAgentService } from '../agents/services/newsletter-agent.service';
 import { WritingStyleExample } from 'src/writing-styles/entities/writing-style-example.entity';
+import { UploadedFile } from '../uploaded-files/entities/uploaded-file.entity';
 
 @Injectable()
 export class ArticlesService {
@@ -37,6 +41,8 @@ export class ArticlesService {
     private readonly newsletterAgentService: NewsletterAgentService,
     @InjectRepository(WritingStyleExample)
     private readonly writingStyleExampleRepository: EntityRepository<WritingStyleExample>,
+    @InjectRepository(UploadedFile)
+    private readonly uploadedFileRepository: EntityRepository<UploadedFile>,
   ) {}
 
   /**
@@ -658,6 +664,232 @@ export class ArticlesService {
 
     } catch (error) {
       this.logger.error(`❌ Background generation failed for articleId=${articleId}:`, error);
+
+      try {
+        // 실패 상태로 업데이트
+        const article = await this.articleRepository.findOne({ articleId });
+        if (article) {
+          article.generationStatus = 'failed';
+          await this.em.persistAndFlush(article);
+        }
+      } catch (updateError) {
+        this.logger.error(`❌ Failed to update error status for articleId=${articleId}:`, updateError);
+      }
+    }
+  }
+
+  // ========== V3 API Methods (PDF 지원) ==========
+
+  /**
+   * V3 API: 비동기 아티클 생성 - PDF 업로드 지원
+   */
+  async generateArticleV3(
+    userId: number,
+    generateDto: GenerateArticleV3Dto,
+  ): Promise<GenerateArticleV2Response> {
+    this.logger.log(`🚀 Starting V2 async article generation for user ${userId}`);
+
+    // 사용자 검증
+    const user = await this.userRepository.findOne({ userId: userId });
+    if (!user) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+
+    // 즉시 processing 상태로 아티클 생성
+    const article = new Article();
+    article.topic = generateDto.topic;
+    article.keyInsight = generateDto.keyInsight;
+    article.generationParams = generateDto.generationParams;
+    article.generationStatus = 'processing';
+    article.user = user;
+
+    await this.em.persistAndFlush(article);
+
+    // 백그라운드에서 실제 생성 작업 실행
+    setImmediate(async () => {
+      await this.performBackgroundGenerationV3(article.articleId, generateDto);
+    });
+
+    this.logger.log(`✅ V2 article generation queued: articleId=${article.articleId}`);
+
+    return {
+      articleId: article.articleId,
+      status: 'processing',
+      message: '뉴스레터 생성이 시작되었습니다.',
+      createdAt: article.createdAt,
+    };
+  }
+
+  /**
+   * V2 API: 아티클 상태 확인 (PDF 진행률 포함)
+   */
+  async getArticleStatusV3(articleId: number): Promise<ArticleStatusV2Response> {
+    const article = await this.articleRepository.findOne(
+      { articleId, isDeleted: false },
+      { populate: ['user', 'archives'] }
+    );
+
+    if (!article) {
+      throw new NotFoundException('아티클을 찾을 수 없습니다.');
+    }
+
+    const latestArchive = article.getLatestArchive();
+
+    const response: ArticleStatusV2Response = {
+      articleId: article.articleId,
+      status: article.generationStatus,
+      title: latestArchive?.title,
+      content: latestArchive?.content,
+      createdAt: article.createdAt,
+    };
+
+    return response;
+  }
+
+  /**
+   * V2 API: 사용자별 아티클 조회 (PDF 정보 포함)
+   */
+  async findByUserV3(userId: number): Promise<any[]> {
+    const user = await this.userRepository.findOne({ userId });
+
+    if (!user) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+
+    const articles = await this.articleRepository.find(
+      { user, isDeleted: false },
+      {
+        populate: ['user', 'archives'],
+        orderBy: { createdAt: 'DESC' },
+      },
+    );
+
+    // 각 아티클에 대해 PDF 정보를 포함한 응답 생성
+    return articles.map((article) => ({
+      articleId: article.articleId,
+      title: article.getLatestTitle() || article.topic,
+      content: article.getLatestContent()?.substring(0, 100) || '',
+      topic: article.topic,
+      keyInsight: article.keyInsight,
+      generationParams: article.generationParams,
+      generationStatus: article.generationStatus,
+      createdAt: article.createdAt,
+      updatedAt: article.updatedAt,
+      user: article.user,
+      // V3에서는 PDF 참고 자료 정보도 포함할 수 있음 (추후 구현)
+      pdfReferences: [], // 임시로 빈 배열
+    }));
+  }
+
+  /**
+   * V3 백그라운드에서 실제 아티클 생성 수행 (PDF 지원)
+   */
+  private async performBackgroundGenerationV3(
+    articleId: number,
+    generateDto: GenerateArticleV3Dto,
+  ): Promise<void> {
+    try {
+      this.logger.log(`🔄 V3 Background generation started for articleId=${articleId}`);
+
+      // 아티클 다시 조회
+      const article = await this.articleRepository.findOne(
+        { articleId },
+        { populate: ['user'] }
+      );
+      
+      if (!article) {
+        this.logger.error(`❌ Article not found during background generation: ${articleId}`);
+        return;
+      }
+
+      // 스크랩 데이터 준비 (V2와 동일)
+      let scrapsWithComments: Array<{ scrap: Scrap; userComment?: string }> = [];
+
+      if (generateDto.scrapWithOptionalComment && generateDto.scrapWithOptionalComment.length > 0) {
+        const scraps = await this.scrapRepository.find({
+          scrapId: {
+            $in: generateDto.scrapWithOptionalComment.map(comment => comment.scrapId),
+          },
+          user: article.user,
+          isDeleted: false,
+        });
+
+        scrapsWithComments = scraps.map((scrap) => {
+          const scrapComment = generateDto.scrapWithOptionalComment?.find(
+            (comment) => comment.scrapId === scrap.scrapId,
+          );
+          return {
+            scrap,
+            userComment: scrapComment?.userComment,
+          };
+        });
+      }
+
+      // PDF 업로드 데이터 준비
+      let pdfUploadsWithPrompts: Array<{ url: string; usagePrompt: string; aiContent: string }> = [];
+      
+      if (generateDto.uploadWithUsagePrompt && generateDto.uploadWithUsagePrompt.length > 0) {
+        // TODO: LibraryItem 엔티티에서 실제 PDF 데이터를 가져와야 함
+        // 현재는 ID와 프롬프트만 저장
+        const uploadedFileIds = generateDto.uploadWithUsagePrompt.map(upload => upload.uploadedFileId);
+        const uploadedFiles = await this.uploadedFileRepository.find({ uploadedFileId: { $in: uploadedFileIds } });
+        pdfUploadsWithPrompts = uploadedFiles.map(file => ({
+          url: file.filePath,
+          usagePrompt: generateDto.uploadWithUsagePrompt?.find(upload => upload.uploadedFileId === file.uploadedFileId)?.usagePrompt || '',
+          aiContent: file.aiContent || '',
+        }));
+      }
+
+      // 문체 예시 준비
+      let writingStyleExampleContents: string[] = [];
+      if (generateDto.writingStyleId) {
+        const writingStyleExamples = await this.writingStyleExampleRepository.find(
+          { writingStyle: { id: generateDto.writingStyleId, user: article.user } },
+          { populate: ['writingStyle'] },
+        );
+        writingStyleExampleContents = writingStyleExamples.map((example) => example.content);
+      }
+
+      // Convert scrapsWithComments to the format expected by FastAPI
+      const formattedScrapsWithComments = scrapsWithComments.map(item => ({
+        scrap: {
+          id: item.scrap.scrapId,
+          title: item.scrap.title,
+          url: item.scrap.url,
+          content: item.scrap.content,
+          userComment: item.scrap.userComment,
+        },
+        userComment: item.userComment,
+      }));
+
+      // V3: AI 뉴스레터 생성 (PDF 정보 포함)
+      const newsletterResult = await this.newsletterAgentService.generateNewsletter({
+        topic: generateDto.topic,
+        keyInsight: generateDto.keyInsight,
+        scrapsWithComments: formattedScrapsWithComments,
+        generationParams: generateDto.generationParams,
+        articleStructureTemplate: generateDto.articleStructureTemplate,
+        writingStyleExampleContents,
+        // V3에서 추가: PDF 업로드 정보
+        pdfUrlsWithPrompts: pdfUploadsWithPrompts, // 이 부분은 newsletterAgentService에서 지원해야 함
+      });
+
+      // AI 생성 결과를 아카이브에 저장
+      const archive = new ArticleArchive();
+      archive.title = newsletterResult.title;
+      archive.content = newsletterResult.content;
+      archive.versionNumber = 1;
+      archive.article = article;
+
+      // 아티클 상태 업데이트
+      article.generationStatus = 'completed';
+
+      await this.em.persistAndFlush([archive, article]);
+
+      this.logger.log(`🎉 V3 Background generation completed for articleId=${articleId}`);
+
+    } catch (error) {
+      this.logger.error(`❌ V3 Background generation failed for articleId=${articleId}:`, error);
 
       try {
         // 실패 상태로 업데이트

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -832,7 +832,10 @@ export class ArticlesService {
         // TODO: LibraryItem 엔티티에서 실제 PDF 데이터를 가져와야 함
         // 현재는 ID와 프롬프트만 저장
         const uploadedFileIds = generateDto.uploadWithUsagePrompt.map(upload => upload.uploadedFileId);
-        const uploadedFiles = await this.uploadedFileRepository.find({ uploadedFileId: { $in: uploadedFileIds } });
+        const uploadedFiles = await this.uploadedFileRepository.find({ 
+          uploadedFileId: { $in: uploadedFileIds },
+          user: article.user,
+        });
         pdfUploadsWithPrompts = uploadedFiles.map(file => ({
           url: file.filePath,
           usagePrompt: generateDto.uploadWithUsagePrompt?.find(upload => upload.uploadedFileId === file.uploadedFileId)?.usagePrompt || '',

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -687,7 +687,7 @@ export class ArticlesService {
     userId: number,
     generateDto: GenerateArticleV3Dto,
   ): Promise<GenerateArticleV2Response> {
-    this.logger.log(`🚀 Starting V2 async article generation for user ${userId}`);
+    this.logger.log(`🚀 Starting V3 async article generation for user ${userId}`);
 
     // 사용자 검증
     const user = await this.userRepository.findOne({ userId: userId });
@@ -710,7 +710,7 @@ export class ArticlesService {
       await this.performBackgroundGenerationV3(article.articleId, generateDto);
     });
 
-    this.logger.log(`✅ V2 article generation queued: articleId=${article.articleId}`);
+    this.logger.log(`✅ V3 article generation queued: articleId=${article.articleId}`);
 
     return {
       articleId: article.articleId,

--- a/src/uploaded-files/entities/uploaded-file.entity.ts
+++ b/src/uploaded-files/entities/uploaded-file.entity.ts
@@ -13,10 +13,10 @@ export class UploadedFile {
   @Property({ name: 'description' })
   description: string;
 
-  @Property({ name: 'file_name' })
+  @Property({ name: 'file_name', type: 'varchar', length: 255 })
   fileName: string;
 
-  @Property({ name: 'file_path' })
+  @Property({ name: 'file_path', type: 'text' })
   filePath: string;
 
   @Property({ name: 'mime_type' })

--- a/src/uploaded-files/uploaded-files.service.ts
+++ b/src/uploaded-files/uploaded-files.service.ts
@@ -11,6 +11,8 @@ import { FileAnalysisProducerService } from '../queue/services/file-analysis-pro
 import { FileAnalysisMessage } from '../queue/dto/file-analysis.dto';
 import { JobStatusService } from '../queue/services/job-status.service';
 import { JobStatus } from '../queue/entities/job-status.entity';
+import { v4 as uuidv4 } from 'uuid';
+import { createHash } from 'crypto';
 @Injectable()
 export class UploadedFilesService {
   private readonly logger = new Logger(UploadedFilesService.name);
@@ -140,8 +142,8 @@ export class UploadedFilesService {
       }
 
       // S3 업로드를 위한 키 생성
-      const safeName = file.originalname.replace(/[^a-zA-Z0-9.\-_]/g, '_');
-      const fileKey = `uploads/${userId}/${Date.now()}-${safeName}`;
+      const hashDirectory = createHash('sha512').update(userId.toString()).digest('hex').substring(0, 8);
+      const fileKey = `uploads/${hashDirectory}/${uuidv4()}`;
       
       // 파일을 스트림으로 업로드 (메모리 부담 줄이기)
       const tmpPath = (file as any).path as string | undefined;


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-314](https://linear.app/chill-mato/issue/CHI-314/)

## 📋 변경사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- 초안 생성 시 pdf 업로드 버전 api v3로 추가
- Agent와 PDF 생성 연동 추가
- 파일 업로드 시 용량 제한 변경
- s3에 파일 저장 시 경로 보안 강화: `userId 해시`/`uuid` 구조로 변경

## 🗃️ 데이터베이스 변경사항
- `uploaded-files` 의 컬럼 타입 변경

## 📦 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음
