### PR TITLE
[CHI-339] 해적 지표 관리를 위한 이벤트 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "langchain": "^0.3.29",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
+        "posthog-node": "^5.8.3",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "turndown": "^7.2.0",
@@ -4743,6 +4744,12 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.0.2.tgz",
+      "integrity": "sha512-hWk3rUtJl2crQK0WNmwg13n82hnTwB99BT99/XI5gZSvIlYZ1TPmMZE8H2dhJJ98J/rm9vYJ/UXNzw3RV5HTpQ==",
+      "license": "MIT"
     },
     "node_modules/@rushstack/node-core-library": {
       "version": "5.13.0",
@@ -14064,6 +14071,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.8.3.tgz",
+      "integrity": "sha512-eFBUEF8Dn/gZncGDNGlC5FqggwRgf/N4ERkzVZsvhvkjXlM6ncSHb7McJsj1hooWGkxrvn/gABfl2hpDurSb/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.0.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "langchain": "^0.3.29",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
+    "posthog-node": "^5.8.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "turndown": "^7.2.0",

--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PosthogService } from './posthog.service';
+
+@Module({
+  providers: [PosthogService],
+  exports: [PosthogService],
+})
+export class AnalyticsModule {}
+

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -1,0 +1,7 @@
+export const EVENT_NAMES = {
+  // Activation
+  ACTIVATION_FIRST_SCRAP: 'activation_first_scrap',
+  ACTIVATION_FIRST_AI_DRAFT_COMPLETED: 'activation_first_ai_draft_completed',
+} as const;
+
+export type EventName = typeof EVENT_NAMES[keyof typeof EVENT_NAMES];

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -1,7 +1,9 @@
 export const EVENT_NAMES = {
-  // Activation
-  ACTIVATION_FIRST_SCRAP: 'activation_first_scrap',
-  ACTIVATION_FIRST_AI_DRAFT_COMPLETED: 'activation_first_ai_draft_completed',
+  // Acquisition
+  ACQUISITION_SIGNUP_COMPLETED: 'acquisition_signup_completed',
+  // Activity (for retention & funnels)
+  ACTIVITY_SCRAP_CREATED: 'activity_scrap_created',
+  ACTIVITY_AI_DRAFT_COMPLETED: 'activity_ai_draft_completed',
 } as const;
 
 export type EventName = typeof EVENT_NAMES[keyof typeof EVENT_NAMES];

--- a/src/analytics/posthog.service.ts
+++ b/src/analytics/posthog.service.ts
@@ -1,0 +1,57 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PostHog } from 'posthog-node';
+
+@Injectable()
+export class PosthogService {
+  private readonly logger = new Logger(PosthogService.name);
+  private client: PostHog | null = null;
+
+  constructor() {
+    const apiKey = process.env.POSTHOG_API_KEY;
+    const host = process.env.POSTHOG_HOST || 'https://us.i.posthog.com';
+
+    if (!apiKey) {
+      this.logger.warn('POSTHOG_API_KEY not set. Analytics disabled.');
+      this.client = null;
+      return;
+    }
+
+    try {
+      this.client = new PostHog(apiKey, { host });
+      this.logger.log(`PostHog client initialized with host: ${host}`);
+    } catch (err) {
+      this.logger.error('Failed to initialize PostHog client', err as Error);
+      this.client = null;
+    }
+  }
+
+  isEnabled(): boolean {
+    return !!this.client;
+  }
+
+  capture(distinctId: string, event: string, properties?: Record<string, any>) {
+    if (!this.client) return;
+    try {
+      this.client.capture({ distinctId, event, properties });
+    } catch (err) {
+      this.logger.warn(`PostHog capture failed for event=${event}`, err as Error);
+    }
+  }
+
+  identify(distinctId: string, set?: Record<string, any>, setOnce?: Record<string, any>) {
+    if (!this.client) return;
+    try {
+      // posthog-node IdentifyMessage does not support $set_once in this version.
+      // Merge properties as a best-effort; caller should avoid relying on set_once semantics here.
+      const properties = { ...(set || {}), ...(setOnce || {}) };
+      this.client.identify({ distinctId, properties });
+    } catch (err) {
+      this.logger.warn(`PostHog identify failed for distinctId=${distinctId}`, err as Error);
+    }
+  }
+
+  shutdown(): void {
+    if (!this.client) return;
+    this.client.shutdown();
+  }
+}

--- a/src/articles/articles.module.ts
+++ b/src/articles/articles.module.ts
@@ -9,11 +9,13 @@ import { Scrap } from '../scraps/entities/scrap.entity';
 import { User } from '../users/entities/user.entity';
 import { WritingStyleExample } from 'src/writing-styles/entities/writing-style-example.entity';
 import { UploadedFile } from '../uploaded-files/entities/uploaded-file.entity';
+import { AnalyticsModule } from '../analytics/analytics.module';
 
 @Module({
   imports: [
     MikroOrmModule.forFeature([Article, ArticleArchive, Scrap, User, WritingStyleExample, UploadedFile]),
     AgentsModule,
+    AnalyticsModule,
   ],
   controllers: [ArticlesController],
   providers: [ArticlesService],

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -201,13 +201,8 @@ export class ArticlesService {
     archive.article = article;
     await this.em.persistAndFlush(archive);
 
-    // Removed first-AI activation event (using generic activity events in funnel)
-
     // Always emit activity event for retention
-    if (this.posthog.isEnabled()) {
-      const distinctId = user.email || String(user.userId);
-      this.posthog.capture(distinctId, EVENT_NAMES.ACTIVITY_AI_DRAFT_COMPLETED);
-    }
+    this.trackAiGenerateArticleDraftEvent(user);
 
     return {
       id: article.articleId,
@@ -216,6 +211,13 @@ export class ArticlesService {
       createdAt: article.createdAt,
       userId: user.userId,
     } as GenerateArticleResponse;
+  }
+
+  private trackAiGenerateArticleDraftEvent(user) {
+    if (this.posthog.isEnabled()) {
+      const distinctId = user.email || String(user.userId);
+      this.posthog.capture(distinctId, EVENT_NAMES.ACTIVITY_AI_DRAFT_COMPLETED);
+    }
   }
 
   /**
@@ -675,13 +677,7 @@ export class ArticlesService {
 
       this.logger.log(`🎉 Background generation completed for articleId=${articleId}`);
 
-      // Removed first-AI activation event
-
-      // Activity event for retention
-      if (this.posthog.isEnabled()) {
-        const distinctId = article.user.email || String(article.user.userId);
-        this.posthog.capture(distinctId, EVENT_NAMES.ACTIVITY_AI_DRAFT_COMPLETED);
-      }
+      this.trackAiGenerateArticleDraftEvent(article.user);
 
     } catch (error) {
       this.logger.error(`❌ Background generation failed for articleId=${articleId}:`, error);
@@ -912,13 +908,7 @@ export class ArticlesService {
 
       this.logger.log(`🎉 V3 Background generation completed for articleId=${articleId}`);
 
-      // Removed first-AI activation event
-
-      // Activity event for retention
-      if (this.posthog.isEnabled()) {
-        const distinctId = article.user.email || String(article.user.userId);
-        this.posthog.capture(distinctId, EVENT_NAMES.ACTIVITY_AI_DRAFT_COMPLETED);
-      }
+      this.trackAiGenerateArticleDraftEvent(article.user);
 
     } catch (error) {
       this.logger.error(`❌ V3 Background generation failed for articleId=${articleId}:`, error);

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -23,6 +23,8 @@ import { EntityManager, EntityRepository } from '@mikro-orm/core';
 import { NewsletterAgentService } from '../agents/services/newsletter-agent.service';
 import { WritingStyleExample } from 'src/writing-styles/entities/writing-style-example.entity';
 import { UploadedFile } from '../uploaded-files/entities/uploaded-file.entity';
+import { PosthogService } from '../analytics/posthog.service';
+import { EVENT_NAMES } from '../analytics/events';
 
 @Injectable()
 export class ArticlesService {
@@ -43,6 +45,7 @@ export class ArticlesService {
     private readonly writingStyleExampleRepository: EntityRepository<WritingStyleExample>,
     @InjectRepository(UploadedFile)
     private readonly uploadedFileRepository: EntityRepository<UploadedFile>,
+    private readonly posthog: PosthogService,
   ) {}
 
   /**
@@ -114,6 +117,12 @@ export class ArticlesService {
     if (!user) {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
     }
+
+    // Check if this user has any previously completed articles (before creating one now)
+    const existingCompleted = await this.articleRepository.findOne(
+      { user, isDeleted: false, generationStatus: 'completed' as any },
+      { fields: ['articleId'] as any },
+    );
 
     // 스크랩 데이터 준비
     let scrapsWithComments: Array<{ scrap: Scrap; userComment?: string }> = [];
@@ -195,6 +204,12 @@ export class ArticlesService {
     archive.versionNumber = 1;
     archive.article = article;
     await this.em.persistAndFlush(archive);
+
+    // Fire activation event if first AI draft completion
+    if (!existingCompleted && this.posthog.isEnabled()) {
+      const distinctId = user.email || String(user.userId);
+      this.posthog.capture(distinctId, EVENT_NAMES.ACTIVATION_FIRST_AI_DRAFT_COMPLETED);
+    }
 
     return {
       id: article.articleId,
@@ -656,11 +671,22 @@ export class ArticlesService {
       archive.article = article;
 
       // 아티클 상태 업데이트
+      // Check if user had any completed article before this one
+      const hadCompletedBefore = await this.articleRepository.findOne(
+        { user: article.user, isDeleted: false, generationStatus: 'completed' as any },
+        { fields: ['articleId'] as any },
+      );
+
       article.generationStatus = 'completed';
 
       await this.em.persistAndFlush([archive, article]);
 
       this.logger.log(`🎉 Background generation completed for articleId=${articleId}`);
+
+      if (!hadCompletedBefore && this.posthog.isEnabled()) {
+        const distinctId = article.user.email || String(article.user.userId);
+        this.posthog.capture(distinctId, EVENT_NAMES.ACTIVATION_FIRST_AI_DRAFT_COMPLETED);
+      }
 
     } catch (error) {
       this.logger.error(`❌ Background generation failed for articleId=${articleId}:`, error);
@@ -885,11 +911,21 @@ export class ArticlesService {
       archive.article = article;
 
       // 아티클 상태 업데이트
+      // Check if user had any completed article before this one
+      const hadCompletedBefore = await this.articleRepository.findOne(
+        { user: article.user, isDeleted: false, generationStatus: 'completed' as any },
+        { fields: ['articleId'] as any },
+      );
       article.generationStatus = 'completed';
 
       await this.em.persistAndFlush([archive, article]);
 
       this.logger.log(`🎉 V3 Background generation completed for articleId=${articleId}`);
+
+      if (!hadCompletedBefore && this.posthog.isEnabled()) {
+        const distinctId = article.user.email || String(article.user.userId);
+        this.posthog.capture(distinctId, EVENT_NAMES.ACTIVATION_FIRST_AI_DRAFT_COMPLETED);
+      }
 
     } catch (error) {
       this.logger.error(`❌ V3 Background generation failed for articleId=${articleId}:`, error);

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -118,11 +118,7 @@ export class ArticlesService {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
     }
 
-    // Check if this user has any previously completed articles (before creating one now)
-    const existingCompleted = await this.articleRepository.findOne(
-      { user, isDeleted: false, generationStatus: 'completed' as any },
-      { fields: ['articleId'] as any },
-    );
+    // Removed: first-completion existence check (using generic activity events)
 
     // 스크랩 데이터 준비
     let scrapsWithComments: Array<{ scrap: Scrap; userComment?: string }> = [];
@@ -205,10 +201,12 @@ export class ArticlesService {
     archive.article = article;
     await this.em.persistAndFlush(archive);
 
-    // Fire activation event if first AI draft completion
-    if (!existingCompleted && this.posthog.isEnabled()) {
+    // Removed first-AI activation event (using generic activity events in funnel)
+
+    // Always emit activity event for retention
+    if (this.posthog.isEnabled()) {
       const distinctId = user.email || String(user.userId);
-      this.posthog.capture(distinctId, EVENT_NAMES.ACTIVATION_FIRST_AI_DRAFT_COMPLETED);
+      this.posthog.capture(distinctId, EVENT_NAMES.ACTIVITY_AI_DRAFT_COMPLETED);
     }
 
     return {
@@ -671,21 +669,18 @@ export class ArticlesService {
       archive.article = article;
 
       // 아티클 상태 업데이트
-      // Check if user had any completed article before this one
-      const hadCompletedBefore = await this.articleRepository.findOne(
-        { user: article.user, isDeleted: false, generationStatus: 'completed' as any },
-        { fields: ['articleId'] as any },
-      );
-
       article.generationStatus = 'completed';
 
       await this.em.persistAndFlush([archive, article]);
 
       this.logger.log(`🎉 Background generation completed for articleId=${articleId}`);
 
-      if (!hadCompletedBefore && this.posthog.isEnabled()) {
+      // Removed first-AI activation event
+
+      // Activity event for retention
+      if (this.posthog.isEnabled()) {
         const distinctId = article.user.email || String(article.user.userId);
-        this.posthog.capture(distinctId, EVENT_NAMES.ACTIVATION_FIRST_AI_DRAFT_COMPLETED);
+        this.posthog.capture(distinctId, EVENT_NAMES.ACTIVITY_AI_DRAFT_COMPLETED);
       }
 
     } catch (error) {
@@ -911,20 +906,18 @@ export class ArticlesService {
       archive.article = article;
 
       // 아티클 상태 업데이트
-      // Check if user had any completed article before this one
-      const hadCompletedBefore = await this.articleRepository.findOne(
-        { user: article.user, isDeleted: false, generationStatus: 'completed' as any },
-        { fields: ['articleId'] as any },
-      );
       article.generationStatus = 'completed';
 
       await this.em.persistAndFlush([archive, article]);
 
       this.logger.log(`🎉 V3 Background generation completed for articleId=${articleId}`);
 
-      if (!hadCompletedBefore && this.posthog.isEnabled()) {
+      // Removed first-AI activation event
+
+      // Activity event for retention
+      if (this.posthog.isEnabled()) {
         const distinctId = article.user.email || String(article.user.userId);
-        this.posthog.capture(distinctId, EVENT_NAMES.ACTIVATION_FIRST_AI_DRAFT_COMPLETED);
+        this.posthog.capture(distinctId, EVENT_NAMES.ACTIVITY_AI_DRAFT_COMPLETED);
       }
 
     } catch (error) {

--- a/src/scraps/scraps.module.ts
+++ b/src/scraps/scraps.module.ts
@@ -6,11 +6,13 @@ import { ScrapsController } from '../api/scraps/scraps.controller';
 import { User } from '../users/entities/user.entity';
 import { Article } from '../articles/entities/article.entity';
 import { TagsModule } from '../tags/tags.module';
+import { AnalyticsModule } from '../analytics/analytics.module';
 
 @Module({
   imports: [
     MikroOrmModule.forFeature([Scrap, User, Article]),
     TagsModule,
+    AnalyticsModule,
   ],
   controllers: [ScrapsController],
   providers: [ScrapsService],

--- a/src/scraps/scraps.service.ts
+++ b/src/scraps/scraps.service.ts
@@ -6,6 +6,8 @@ import { Scrap } from './entities/scrap.entity';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { User } from '../users/entities/user.entity';
 import { Article } from '../articles/entities/article.entity';
+import { PosthogService } from '../analytics/posthog.service';
+import { EVENT_NAMES } from '../analytics/events';
 
 export interface SearchOptions {
   query?: string;
@@ -33,6 +35,7 @@ export class ScrapsService {
     private readonly userRepository: EntityRepository<User>,
     @InjectRepository(Article)
     private readonly articleRepository: EntityRepository<Article>,
+    private readonly posthog: PosthogService,
   ) {}
 
   async create(
@@ -44,6 +47,12 @@ export class ScrapsService {
     if (!user) {
       throw new Error('User not found');
     }
+
+    // Lightweight existence check BEFORE creating, to detect first scrap
+    const existing = await this.scrapRepository.findOne(
+      { user: { userId }, isDeleted: false },
+      { fields: ['scrapId'] as any },
+    );
 
     const article = articleId
       ? await this.articleRepository.findOne({ articleId, isDeleted: false })
@@ -67,6 +76,13 @@ export class ScrapsService {
 
     await this.em.persistAndFlush(scrap);
     scrap.content = scrap.content.substring(0, 100);
+
+    // Fire activation event on first scrap
+    if (!existing && this.posthog.isEnabled()) {
+      const distinctId = user.email || String(user.userId);
+      // Send bare activation event without any properties
+      this.posthog.capture(distinctId, EVENT_NAMES.ACTIVATION_FIRST_SCRAP);
+    }
     return scrap;
   }
 

--- a/src/scraps/scraps.service.ts
+++ b/src/scraps/scraps.service.ts
@@ -73,14 +73,16 @@ export class ScrapsService {
     await this.em.persistAndFlush(scrap);
     scrap.content = scrap.content.substring(0, 100);
 
-    // Removed first-scrap activation event (funnel uses generic activity events)
-
     // Always emit activity event for retention
+    this.trackCreateScrapEvent(user);
+    return scrap;
+  }
+
+  private trackCreateScrapEvent(user) {
     if (this.posthog.isEnabled()) {
       const distinctId = user.email || String(user.userId);
       this.posthog.capture(distinctId, EVENT_NAMES.ACTIVITY_SCRAP_CREATED);
     }
-    return scrap;
   }
 
   async findAll(userId?: number): Promise<Scrap[]> {

--- a/src/scraps/scraps.service.ts
+++ b/src/scraps/scraps.service.ts
@@ -48,11 +48,7 @@ export class ScrapsService {
       throw new Error('User not found');
     }
 
-    // Lightweight existence check BEFORE creating, to detect first scrap
-    const existing = await this.scrapRepository.findOne(
-      { user: { userId }, isDeleted: false },
-      { fields: ['scrapId'] as any },
-    );
+    // Removed first-scrap existence check (no longer needed for activation event)
 
     const article = articleId
       ? await this.articleRepository.findOne({ articleId, isDeleted: false })
@@ -77,11 +73,12 @@ export class ScrapsService {
     await this.em.persistAndFlush(scrap);
     scrap.content = scrap.content.substring(0, 100);
 
-    // Fire activation event on first scrap
-    if (!existing && this.posthog.isEnabled()) {
+    // Removed first-scrap activation event (funnel uses generic activity events)
+
+    // Always emit activity event for retention
+    if (this.posthog.isEnabled()) {
       const distinctId = user.email || String(user.userId);
-      // Send bare activation event without any properties
-      this.posthog.capture(distinctId, EVENT_NAMES.ACTIVATION_FIRST_SCRAP);
+      this.posthog.capture(distinctId, EVENT_NAMES.ACTIVITY_SCRAP_CREATED);
     }
     return scrap;
   }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -3,9 +3,10 @@ import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { User } from './entities/user.entity';
 import { UsersService } from './users.service';
 import { UserOAuth } from './entities/user-oauth.entity';
+import { AnalyticsModule } from '../analytics/analytics.module';
 
 @Module({
-  imports: [MikroOrmModule.forFeature([User, UserOAuth])],
+  imports: [MikroOrmModule.forFeature([User, UserOAuth]), AnalyticsModule],
   providers: [UsersService],
   exports: [UsersService],
 })

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -56,11 +56,15 @@ export class UsersService {
     Object.assign(user, userData);
     await this.em.persistAndFlush(user);
     // Acquisition event: signup completed (only for new users)
+    this.trackSignUpEvent(user);
+    return user;
+  }
+
+  private trackSignUpEvent(user: User) {
     if (this.posthog.isEnabled()) {
       const distinctId = user.email || String(user.userId);
       this.posthog.capture(distinctId, EVENT_NAMES.ACQUISITION_SIGNUP_COMPLETED);
     }
-    return user;
   }
 
   /**
@@ -110,11 +114,9 @@ export class UsersService {
       user.email = data.email;
       user.name = data.name;
       await this.em.persistAndFlush(user);
+      
       // Acquisition event for first-time user creation via OAuth
-      if (this.posthog.isEnabled()) {
-        const distinctId = user.email || String(user.userId);
-        this.posthog.capture(distinctId, EVENT_NAMES.ACQUISITION_SIGNUP_COMPLETED);
-      }
+      this.trackSignUpEvent(user);
     }
 
     // 3. OAuth 계정 연결

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -3,6 +3,8 @@ import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 import { User } from './entities/user.entity';
 import { UserOAuth, OAuthProvider } from './entities/user-oauth.entity';
 import { InjectRepository } from '@mikro-orm/nestjs';
+import { PosthogService } from '../analytics/posthog.service';
+import { EVENT_NAMES } from '../analytics/events';
 
 /**
  * OAuth 사용자 생성 데이터
@@ -32,6 +34,7 @@ export class UsersService {
     private readonly userRepository: EntityRepository<User>,
     @InjectRepository(UserOAuth)
     private readonly userOAuthRepository: EntityRepository<UserOAuth>,
+    private readonly posthog: PosthogService,
   ) {}
 
   async findOne(id: number): Promise<User | null> {
@@ -52,6 +55,11 @@ export class UsersService {
     const user = new User();
     Object.assign(user, userData);
     await this.em.persistAndFlush(user);
+    // Acquisition event: signup completed (only for new users)
+    if (this.posthog.isEnabled()) {
+      const distinctId = user.email || String(user.userId);
+      this.posthog.capture(distinctId, EVENT_NAMES.ACQUISITION_SIGNUP_COMPLETED);
+    }
     return user;
   }
 
@@ -102,6 +110,11 @@ export class UsersService {
       user.email = data.email;
       user.name = data.name;
       await this.em.persistAndFlush(user);
+      // Acquisition event for first-time user creation via OAuth
+      if (this.posthog.isEnabled()) {
+        const distinctId = user.email || String(user.userId);
+        this.posthog.capture(distinctId, EVENT_NAMES.ACQUISITION_SIGNUP_COMPLETED);
+      }
     }
 
     // 3. OAuth 계정 연결


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-339](https://linear.app/chill-mato/issue/CHI-339/)

## 📋 변경사항 요약
- Analytics 모듈 도입 및 PostHog 연동
  - `AnalyticsModule`, `PosthogService` 추가 (API 키/호스트 기반 초기화)
- 이벤트 스키마
  - Acquisition: `acquisition_signup_completed` (신규 가입 시 1회 전송)
  - Activity: `activity_scrap_created`(스크랩 생성 시마다), `activity_ai_draft_completed`(AI 초안 완료 시마다)
- 퍼널 단순화
  - “첫 스크랩/첫 초안” 이벤트 및 선행 조회 제거
  - 퍼널은 “가입 → 스크랩 → 초안생성” 일반 이벤트로 구성
- 주요 코드 변경
  - `users.service.ts`: 신규 유저 생성 시 `acquisition_signup_completed` 전송
  - `scraps.service.ts`: 스크랩 생성 시 `activity_scrap_created` 전송
  - `articles.service.ts`: AI 초안 완료(V1/V2/V3) 시 `activity_ai_draft_completed` 전송
  - `events.ts`: 이벤트 상수 정의(획득/활동)
  - 모듈 임포트: `AppModule`, `ArticlesModule`, `ScrapsModule`, `UsersModule`에 `AnalyticsModule` 연결

## 🗃️ 데이터베이스 변경사항
- 없음

## 📦 빌드 & 배포
- 환경 변수
  - 필수: `POSTHOG_API_KEY`
  - 선택: `POSTHOG_HOST` (기본값 `https://us.i.posthog.com`)

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음

## 참고 사항
현재 extension에서 posthog 추가 시 승인 문제로 임시 작업으로 추후 제거 될 예정
