### PR TITLE
[CHI-362] PDF 업로드 시 분석 기능 완전 제거

### DIFF
--- a/src/api/uploaded-files/uploaded-files.controller.ts
+++ b/src/api/uploaded-files/uploaded-files.controller.ts
@@ -12,9 +12,6 @@ import {
   UseInterceptors,
   UploadedFile,
   Req,
-  HttpCode,
-  HttpStatus,
-  ParseIntPipe,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
@@ -25,11 +22,6 @@ import { UploadedFilesService } from '../../uploaded-files/uploaded-files.servic
 import { UpdateUploadedFileDto } from './dto/update-uploaded-file.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 
-interface RetryAnalysisResponseDto {
-  jobUuid: string | null;
-  status: 'queued' | 'error';
-  error?: string;
-}
 
 @Controller('uploaded-files')
 export class UploadedFilesController {
@@ -112,22 +104,4 @@ export class UploadedFilesController {
     return { message: 'Uploaded file deleted successfully' };
   }
 
-  @Version('1')
-  @Get(':id/analysis')
-  @UseGuards(JwtAuthGuard)
-  async getAnalysis(@Req() req: any, @Param('id') id: string) {
-    const data = await this.uploadedFilesService.getAnalysis(+id, req.user.id);
-    return data;
-  }
-
-  @Version('1')
-  @Post(':id/analysis/retry')
-  @UseGuards(JwtAuthGuard)
-  @HttpCode(HttpStatus.ACCEPTED)
-  async retryAnalysis(
-    @Req() req: any,
-    @Param('id', ParseIntPipe) id: number,
-  ): Promise<RetryAnalysisResponseDto> {
-    return await this.uploadedFilesService.retryAnalysis(id, req.user.id);
-  }
 }

--- a/src/uploaded-files/uploaded-files.module.ts
+++ b/src/uploaded-files/uploaded-files.module.ts
@@ -5,15 +5,11 @@ import { UploadedFilesController } from '../api/uploaded-files/uploaded-files.co
 import { Scrap } from '../scraps/entities/scrap.entity';
 import { User } from '../users/entities/user.entity';
 import { AuthModule } from '../auth/auth.module';
-import { AgentsModule } from '../agents/agents.module';
-import { QueueModule } from '../queue/queue.module';
 
 @Module({
   imports: [
     MikroOrmModule.forFeature([Scrap, User]),
     AuthModule,
-    AgentsModule,
-    forwardRef(() => QueueModule), // Use forwardRef to avoid circular dependency
   ],
   controllers: [UploadedFilesController],
   providers: [UploadedFilesService],

--- a/src/uploaded-files/uploaded-files.service.ts
+++ b/src/uploaded-files/uploaded-files.service.ts
@@ -13,10 +13,6 @@ import { Scrap } from '../scraps/entities/scrap.entity';
 import { User } from '../users/entities/user.entity';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import * as fs from 'fs';
-import { FileAnalysisProducerService } from '../queue/services/file-analysis-producer.service';
-import { FileAnalysisMessage } from '../queue/dto/file-analysis.dto';
-import { JobStatusService } from '../queue/services/job-status.service';
-import { JobStatus } from '../queue/entities/job-status.entity';
 import { v4 as uuidv4 } from 'uuid';
 import { createHash } from 'crypto';
 @Injectable()
@@ -24,10 +20,6 @@ export class UploadedFilesService {
   private readonly logger = new Logger(UploadedFilesService.name);
   private s3Client: S3Client;
   private bucket: string;
-  private readonly ANALYZABLE_MIME_TYPES = new Set([
-    'application/pdf',
-  ] as const);
-  private readonly MAX_JOB_SEARCH_LIMIT = 50;
 
   constructor(
     private readonly em: EntityManager,
@@ -35,8 +27,6 @@ export class UploadedFilesService {
     private readonly scrapRepository: EntityRepository<Scrap>,
     @InjectRepository(User)
     private readonly userRepository: EntityRepository<User>,
-    private readonly fileAnalysisProducerService: FileAnalysisProducerService,
-    private readonly jobStatusService: JobStatusService,
   ) {
     this.bucket = process.env.AWS_S3_BUCKET || '';
     if (this.bucket === '') {
@@ -111,47 +101,6 @@ export class UploadedFilesService {
     await this.em.removeAndFlush(uploadedFile);
   }
 
-  async getAnalysis(
-    id: number,
-    userId: number,
-  ): Promise<{
-    markdown: string | null;
-    updatedAt?: Date;
-    status?: JobStatus;
-    jobUuid?: string;
-    error?: string;
-  }> {
-    const uploaded = await this.findOne(id, userId);
-
-    // Find the latest job for this uploaded file from recent jobs
-    let jobUuid: string | undefined;
-    let status: JobStatus | undefined;
-    let error: string | undefined;
-    try {
-      const jobs = await this.jobStatusService.getJobsByUser(
-        userId,
-        this.MAX_JOB_SEARCH_LIMIT,
-      );
-      const latest = jobs.find(
-        (j) => j.payload && j.payload.uploadedFileId === id,
-      );
-      if (latest) {
-        jobUuid = latest.jobUuid;
-        status = latest.status;
-        error = latest.errorMessage ?? undefined;
-      }
-    } catch (e) {
-      // ignore job lookup failures; return content only
-    }
-
-    return {
-      markdown: uploaded.aiContent ?? null,
-      updatedAt: uploaded.updatedAt ?? uploaded.createdAt,
-      status,
-      jobUuid,
-      error,
-    };
-  }
 
   async uploadToS3AndSave(
     file: Express.Multer.File,
@@ -201,10 +150,6 @@ export class UploadedFilesService {
         fileSize: file.size,
       });
 
-      // PDF 또는 문서 파일인 경우 AI 분석을 큐에 요청
-      if (this.shouldAnalyzeFile(file.mimetype)) {
-        await this.queueFileAnalysis(uploadedFile, fileUrl);
-      }
 
       // 임시 파일 정리
       if (tmpPath) {
@@ -252,75 +197,4 @@ export class UploadedFilesService {
     return scrap;
   }
 
-  private shouldAnalyzeFile(mimeType: string): boolean {
-    return this.ANALYZABLE_MIME_TYPES.has(mimeType as any);
-  }
-
-  private async queueFileAnalysis(
-    uploadedFile: Scrap,
-    fileUrl: string,
-  ): Promise<string | null> {
-    try {
-      this.logger.log(
-        `📤 Queuing AI analysis for file: ${uploadedFile.fileName}`,
-      );
-
-      const analysisMessage: FileAnalysisMessage = {
-        uploadedFileId: uploadedFile.scrapId,
-        fileUrl: fileUrl,
-        fileName: uploadedFile.fileName!,
-        mimeType: uploadedFile.mimeType!,
-        userId: uploadedFile.user.userId,
-        timestamp: new Date().toISOString(),
-      };
-
-      const jobUuid =
-        await this.fileAnalysisProducerService.sendFileAnalysisRequest(
-          analysisMessage,
-        );
-
-      this.logger.log(
-        `✅ AI analysis queued for file: ${uploadedFile.fileName} (Job: ${jobUuid})`,
-      );
-      return jobUuid;
-    } catch (error) {
-      this.logger.error(
-        `❌ Failed to queue analysis for file ${uploadedFile.fileName}:`,
-        error,
-      );
-      // Don't throw - let the file upload succeed even if queueing fails
-      return null;
-    }
-  }
-
-  async retryAnalysis(
-    id: number,
-    userId: number,
-  ): Promise<{ jobUuid: string | null; status: 'queued' | 'error' }> {
-    const uploaded = await this.findOne(id, userId);
-
-    try {
-      const recentJobs = await this.jobStatusService.getJobsByUser(
-        userId,
-        this.MAX_JOB_SEARCH_LIMIT,
-      );
-      const pendingJob = recentJobs.find(
-        (j) =>
-          j.payload?.uploadedFileId === id &&
-          (j.status === JobStatus.PENDING || j.status === JobStatus.PROCESSING),
-      );
-
-      if (pendingJob) {
-        this.logger.warn(
-          `Analysis already in progress for file ${id} (Job: ${pendingJob.jobUuid})`,
-        );
-        return { jobUuid: pendingJob.jobUuid, status: 'queued' };
-      }
-    } catch (error) {
-      this.logger.error(`❌ Failed to retry analysis for file ${id}:`, error);
-    }
-
-    const jobUuid = await this.queueFileAnalysis(uploaded, uploaded.filePath!);
-    return { jobUuid, status: jobUuid ? 'queued' : 'error' };
-  }
 }


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-362](https://linear.app/chill-mato/issue/CHI-362)

## 📋 변경사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->

백엔드에서 PDF AI 분석 기능 제거. PDF 파일 업로드는 계속 지원하되, AI 서버로 분석 요청을 보내는 기능을 비활성화

### 주요 변경사항
- `UploadedFilesService`에서 AI 분석 큐 로직 제거
  - `queueFileAnalysis()` 메서드 제거
  - `shouldAnalyzeFile()` 메서드 제거
  - `retryAnalysis()` 메서드 제거
  - `getAnalysis()` 메서드 제거
- `UploadedFilesController`에서 분석 관련 엔드포인트 제거
  - `GET /:id/analysis` 엔드포인트 제거
  - `POST /:id/analysis/retry` 엔드포인트 제거
- `UploadedFilesModule`에서 큐 및 에이전트 의존성 제거
  - `QueueModule` 의존성 제거
  - `AgentsModule` 의존성 제거
- 불필요한 import 정리

### 유지되는 기능
- PDF 파일 업로드 및 S3 저장
- 파일 메타데이터 관리
- 파일 다운로드 및 삭제
- Scrap 엔티티의 파일 관련 필드 (fileName, filePath, mimeType, fileSize, aiContent)

## 🗃️ 데이터베이스 변경사항

데이터베이스 스키마 변경 없음.

## 📦 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음