### PR TITLE
[CHI-370] 스크랩 API에 향상된 메타데이터 지원 추가

### DIFF
--- a/src/api/scraps/dto/create-scrap.dto.ts
+++ b/src/api/scraps/dto/create-scrap.dto.ts
@@ -4,8 +4,73 @@ import {
   IsOptional,
   IsNumber,
   IsUrl,
-  MaxLength,
+  IsArray,
+  ValidateNested,
 } from 'class-validator';
+import { Type } from 'class-transformer';
+
+class WebpageSiteInfo {
+  @IsOptional()
+  @IsString()
+  host?: string;
+
+  @IsOptional()
+  @IsString()
+  favicon_url?: string;
+
+  @IsOptional()
+  @IsString()
+  name?: string;
+}
+
+class WebpageMetadata {
+  @IsString()
+  url: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => WebpageSiteInfo)
+  site?: WebpageSiteInfo;
+
+  @IsString()
+  title: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}
+
+class ContentInfo {
+  @IsOptional()
+  @IsString()
+  raw?: string;
+
+  @IsOptional()
+  @IsString()
+  plain?: string;
+
+  @IsOptional()
+  @IsString()
+  text?: string;
+
+  @IsOptional()
+  @IsString()
+  language?: string;
+
+  @IsOptional()
+  @IsString()
+  format?: string;
+}
+
+class AuthorInfo {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  picture?: string;
+}
 
 export class CreateScrapDto {
   @ApiProperty()
@@ -19,6 +84,10 @@ export class CreateScrapDto {
   @ApiProperty()
   @IsString()
   content: string;
+
+  @ApiProperty()
+  @IsString()
+  htmlContent: string;
 
   @ApiProperty({ required: false, description: '스크랩 설명 (요약/메모)' })
   @IsOptional()
@@ -39,8 +108,53 @@ export class CreateScrapDto {
   @IsOptional()
   tags?: string[];
 
-  @ApiProperty()
+  // New metadata fields
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => WebpageMetadata)
+  webpage?: WebpageMetadata;
+
+  @ApiProperty({ required: false })
   @IsOptional()
   @IsString()
-  htmlContent?: string;
+  hero_image_url?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  published_at?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsArray()
+  author_names?: string[];
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsArray()
+  author_pictures?: string[];
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ContentInfo)
+  content_info?: ContentInfo;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  type?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AuthorInfo)
+  authors?: AuthorInfo[];
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  from?: string;
 }

--- a/src/api/scraps/dto/scrap-response.dto.ts
+++ b/src/api/scraps/dto/scrap-response.dto.ts
@@ -134,7 +134,81 @@ export class ScrapResponseDto {
   folders?: {
     folderId: number;
     name: string;
+    color?: string;
   }[];
+
+  // New metadata fields
+  @ApiProperty({
+    description: 'Content information in different formats',
+    required: false,
+  })
+  contentInfo?: {
+    raw?: string;
+    plain?: string;
+    text?: string;
+    language?: string;
+    format?: string;
+  };
+
+  @ApiProperty({
+    description: 'Webpage metadata',
+    required: false,
+  })
+  webpage?: {
+    url?: string;
+    title?: string;
+    description?: string;
+    site?: {
+      host?: string;
+      favicon_url?: string;
+      name?: string;
+    };
+  };
+
+  @ApiProperty({
+    description: 'Hero image URL',
+    required: false,
+    example: 'https://example.com/image.jpg',
+  })
+  heroImageUrl?: string;
+
+  @ApiProperty({
+    description: 'Published date',
+    required: false,
+    example: '2023-01-01T00:00:00Z',
+  })
+  publishedAt?: Date;
+
+  @ApiProperty({
+    description: 'Authors information',
+    required: false,
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', example: 'John Doe' },
+        picture: { type: 'string', example: 'https://example.com/avatar.jpg' },
+      },
+    },
+  })
+  authors?: Array<{
+    name?: string;
+    picture?: string;
+  }>;
+
+  @ApiProperty({
+    description: 'Content type',
+    required: false,
+    example: 'webclip',
+  })
+  type?: string;
+
+  @ApiProperty({
+    description: 'Source of the scrap',
+    required: false,
+    example: 'extension',
+  })
+  from?: string;
 }
 
 export class ScrapSummaryDto {
@@ -242,7 +316,22 @@ export class ScrapSummaryDto {
   folders?: {
     folderId: number;
     name: string;
+    color?: string;
   }[];
+
+  @ApiProperty({
+    description: 'Hero image URL',
+    required: false,
+    example: 'https://example.com/image.jpg',
+  })
+  heroImageUrl?: string;
+
+  @ApiProperty({
+    description: 'Content type',
+    required: false,
+    example: 'webclip',
+  })
+  type?: string;
 }
 
 export class ScrapListResponse {

--- a/src/api/scraps/scraps.controller.ts
+++ b/src/api/scraps/scraps.controller.ts
@@ -386,16 +386,9 @@ export class ScrapsController {
       // Get user's scraps with enhanced metadata
       const scraps = await this.scrapsService.findByUser(userId, sortBy, sortOrder);
 
-      // Return full response DTOs with all metadata fields
-      const fullScraps: ScrapResponseDto[] = [];
-      for (const scrap of scraps) {
-        const fullScrap = await this.scrapsService.findOne(scrap.scrapId);
-        if (fullScrap) {
-          fullScraps.push(fullScrap);
-        }
-      }
-
-      return fullScraps;
+      // Batch fetch full response DTOs with all metadata fields
+      const scrapIds = scraps.map(scrap => scrap.scrapId);
+      return await this.scrapsService.findMany(scrapIds);
     } catch (error: any) {
       throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -428,13 +421,7 @@ export class ScrapsController {
    * Helper method to enrich scraps with enhanced metadata
    */
   private async enrichScrapsWithMetadata(scraps: any[]): Promise<ScrapResponseDto[]> {
-    const enrichedScraps: ScrapResponseDto[] = [];
-    for (const scrap of scraps) {
-      const fullScrap = await this.scrapsService.findOne(scrap.scrapId);
-      if (fullScrap) {
-        enrichedScraps.push(fullScrap);
-      }
-    }
-    return enrichedScraps;
+    const scrapIds = scraps.map(scrap => scrap.scrapId);
+    return await this.scrapsService.findMany(scrapIds);
   }
 }

--- a/src/api/scraps/scraps.controller.ts
+++ b/src/api/scraps/scraps.controller.ts
@@ -318,4 +318,123 @@ export class ScrapsController {
       throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
+
+  // ========== VERSION 2 API - Enhanced Metadata Support ==========
+
+  /**
+   * POST /api/v2/scraps - 스크랩 생성 (향상된 메타데이터 포함)
+   */
+  @Version('2')
+  @Post()
+  async createV2(
+    @Body() createScrapDto: CreateScrapDto,
+    @Request() req: any,
+  ): Promise<ScrapResponseDto> {
+    try {
+      const userId = parseInt(req.user.id);
+      const { articleId, tags, ...scrapData } = createScrapDto;
+
+      // Create scrap with enhanced metadata
+      const scrapSummary = await this.scrapsService.create(scrapData, userId, articleId);
+
+      // Add tags if provided
+      if (tags && tags.length > 0) {
+        for (const tagName of tags) {
+          await this.tagsService.create(
+            { name: tagName, scrapId: scrapSummary.scrapId },
+            userId,
+            scrapSummary.scrapId,
+          );
+        }
+      }
+
+      // Return full scrap with all metadata
+      const fullScrap = await this.scrapsService.findOne(scrapSummary.scrapId);
+      return fullScrap!;
+    } catch (error: any) {
+      throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  /**
+   * GET /api/v2/scraps - 현재 사용자의 스크랩 목록 조회 (향상된 메타데이터 포함)
+   */
+  @Version('2')
+  @Get()
+  async findAllV2(
+    @Request() req: any,
+    @Query('articleId') articleId?: number,
+    @Query('search') search?: string,
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+    @Query('sortBy') sortBy?: 'created_at' | 'updated_at' | 'title',
+    @Query('sortOrder') sortOrder?: 'ASC' | 'DESC',
+  ): Promise<ScrapResponseDto[]> {
+    try {
+      const userId = parseInt(req.user.id);
+
+      if (search) {
+        const scraps = await this.scrapsService.search(search, userId);
+        return this.enrichScrapsWithMetadata(scraps);
+      }
+
+      if (articleId) {
+        const scraps = await this.scrapsService.findByArticle(articleId);
+        return this.enrichScrapsWithMetadata(scraps);
+      }
+
+      // Get user's scraps with enhanced metadata
+      const scraps = await this.scrapsService.findByUser(userId, sortBy, sortOrder);
+
+      // Return full response DTOs with all metadata fields
+      const fullScraps: ScrapResponseDto[] = [];
+      for (const scrap of scraps) {
+        const fullScrap = await this.scrapsService.findOne(scrap.scrapId);
+        if (fullScrap) {
+          fullScraps.push(fullScrap);
+        }
+      }
+
+      return fullScraps;
+    } catch (error: any) {
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * GET /api/v2/scraps/:scrapId - 스크랩 상세 조회 (향상된 메타데이터 포함)
+   */
+  @Version('2')
+  @Get(':scrapId')
+  async findOneV2(
+    @Param('scrapId', ParseIntPipe) scrapId: number,
+  ): Promise<ScrapResponseDto> {
+    try {
+      const scrap = await this.scrapsService.findOne(scrapId);
+      if (!scrap) {
+        throw new HttpException('Scrap not found', HttpStatus.NOT_FOUND);
+      }
+      // V2 returns all enhanced metadata fields
+      return scrap;
+    } catch (error: any) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * Helper method to enrich scraps with enhanced metadata
+   */
+  private async enrichScrapsWithMetadata(scraps: any[]): Promise<ScrapResponseDto[]> {
+    const enrichedScraps: ScrapResponseDto[] = [];
+    for (const scrap of scraps) {
+      const fullScrap = await this.scrapsService.findOne(scrap.scrapId);
+      if (fullScrap) {
+        enrichedScraps.push(fullScrap);
+      }
+    }
+    return enrichedScraps;
+  }
 }

--- a/src/scraps/entities/scrap.entity.ts
+++ b/src/scraps/entities/scrap.entity.ts
@@ -27,6 +27,15 @@ export class Scrap {
   @Property({ name: 'content', type: 'text' })
   content: string;
 
+  @Property({ name: 'content_info', type: 'json', nullable: true })
+  contentInfo?: {
+    raw?: string;     // HTML with tags
+    plain?: string;   // Markdown format
+    text?: string;    // Pure text only
+    language?: string;
+    format?: string;
+  };
+
   @Property({ name: 'html_content', type: 'text' })
   htmlContent: string;
 
@@ -54,6 +63,36 @@ export class Scrap {
 
   @Property({ name: 'user_comment', type: 'text', nullable: true })
   userComment?: string;
+
+  @Property({ name: 'webpage', type: 'json', nullable: true })
+  webpage?: {
+    url?: string;
+    title?: string;
+    description?: string;
+    site?: {
+      host?: string;
+      favicon_url?: string;
+      name?: string;
+    };
+  };
+
+  @Property({ name: 'hero_image_url', type: 'text', nullable: true })
+  heroImageUrl?: string;
+
+  @Property({ name: 'published_at', type: 'timestamp', nullable: true })
+  publishedAt?: Date;
+
+  @Property({ name: 'authors', type: 'json', nullable: true })
+  authors?: Array<{
+    name?: string;
+    picture?: string;
+  }>;
+
+  @Property({ name: 'type', type: 'varchar', length: 50, nullable: true, default: 'webclip' })
+  type?: string;
+
+  @Property({ name: 'from_source', type: 'varchar', length: 50, nullable: true, default: 'extension' })
+  from?: string;
 
   @Property({ name: 'created_at' })
   createdAt: Date = new Date();

--- a/src/scraps/entities/scrap.entity.ts
+++ b/src/scraps/entities/scrap.entity.ts
@@ -27,7 +27,7 @@ export class Scrap {
   @Property({ name: 'content', type: 'text' })
   content: string;
 
-  @Property({ name: 'content_info', type: 'json', nullable: true })
+  @Property({ name: 'content_info', type: 'json', columnType: 'jsonb', nullable: true })
   contentInfo?: {
     raw?: string;     // HTML with tags
     plain?: string;   // Markdown format
@@ -64,7 +64,7 @@ export class Scrap {
   @Property({ name: 'user_comment', type: 'text', nullable: true })
   userComment?: string;
 
-  @Property({ name: 'webpage', type: 'json', nullable: true })
+  @Property({ name: 'webpage', type: 'json', columnType: 'jsonb', nullable: true })
   webpage?: {
     url?: string;
     title?: string;
@@ -82,7 +82,7 @@ export class Scrap {
   @Property({ name: 'published_at', type: 'timestamp', nullable: true })
   publishedAt?: Date;
 
-  @Property({ name: 'authors', type: 'json', nullable: true })
+  @Property({ name: 'authors', type: 'json', columnType: 'jsonb', nullable: true })
   authors?: Array<{
     name?: string;
     picture?: string;

--- a/src/scraps/scraps.service.ts
+++ b/src/scraps/scraps.service.ts
@@ -126,6 +126,39 @@ export class ScrapsService {
     return scrap ? this.toScrapResponseDto(scrap) : null;
   }
 
+  /**
+   * Find multiple scraps by their IDs in a single query
+   * @param scrapIds Array of scrap IDs to fetch
+   * @returns Array of ScrapResponseDto for found scraps
+   */
+  async findMany(scrapIds: number[]): Promise<ScrapResponseDto[]> {
+    if (!scrapIds || scrapIds.length === 0) {
+      return [];
+    }
+
+    const scraps = await this.scrapRepository.find(
+      {
+        scrapId: { $in: scrapIds },
+        isDeleted: false
+      },
+      {
+        populate: ['tags', 'scrapFolders.folder'],
+        filters: { isDeleted: false },
+      },
+    );
+
+    // Convert all found scraps to DTOs and maintain the original order
+    const scrapMap = new Map<number, ScrapResponseDto>();
+    scraps.forEach(scrap => {
+      scrapMap.set(scrap.scrapId, this.toScrapResponseDto(scrap));
+    });
+
+    // Return scraps in the same order as requested IDs
+    return scrapIds
+      .map(id => scrapMap.get(id))
+      .filter((scrap): scrap is ScrapResponseDto => scrap !== undefined);
+  }
+
   async findByUser(
     userId: number,
     sortBy?: 'created_at' | 'updated_at' | 'title',

--- a/src/scraps/scraps.service.ts
+++ b/src/scraps/scraps.service.ts
@@ -63,10 +63,34 @@ export class ScrapsService {
     scrap.url = createScrapDto.url;
     scrap.title = createScrapDto.title;
     scrap.content = createScrapDto.content;
-    scrap.htmlContent = '';
+    scrap.htmlContent = createScrapDto.htmlContent || '';
     scrap.description = createScrapDto.description;
     scrap.userComment = createScrapDto.userComment;
     scrap.user = user;
+
+    // Store new metadata fields
+    if (createScrapDto.webpage) {
+      scrap.webpage = createScrapDto.webpage;
+    }
+
+    if (createScrapDto.content_info) {
+      scrap.contentInfo = createScrapDto.content_info;
+    }
+
+    if (createScrapDto.hero_image_url) {
+      scrap.heroImageUrl = createScrapDto.hero_image_url;
+    }
+
+    if (createScrapDto.published_at) {
+      scrap.publishedAt = new Date(createScrapDto.published_at);
+    }
+
+    if (createScrapDto.authors) {
+      scrap.authors = createScrapDto.authors;
+    }
+
+    scrap.type = createScrapDto.type || 'webclip';
+    scrap.from = createScrapDto.from || 'extension';
 
     if (article) {
       scrap.article = article;
@@ -422,6 +446,8 @@ export class ScrapsService {
           name: sf.folder.name,
           color: sf.folder.color,
         })),
+      heroImageUrl: scrap.heroImageUrl,
+      type: scrap.type,
     };
   }
 
@@ -458,6 +484,14 @@ export class ScrapsService {
           name: sf.folder.name,
           color: sf.folder.color,
         })),
+      // New metadata fields
+      contentInfo: scrap.contentInfo,
+      webpage: scrap.webpage,
+      heroImageUrl: scrap.heroImageUrl,
+      publishedAt: scrap.publishedAt,
+      authors: scrap.authors,
+      type: scrap.type,
+      from: scrap.from,
     };
   }
 }


### PR DESCRIPTION
## 🔗 연관 이슈

Closes: https://linear.app/chill-mato/issue/CHI-370/

## 변경사항 요약

Chrome Extension의 웹 클리핑 기능에서 수집하는 메타데이터를 확장하고, 이를 처리할 수 있도록 백엔드
API를 개선했습니다.

## 주요 변경사항

- Chrome Extension 개선
  - Mozilla Readability 라이브러리 통합으로 콘텐츠 추출 품질 향상
  - 콘텐츠를 3가지 형식으로 분리: raw (HTML), plain (Markdown), text (순수 텍스트)
  - 웹페이지 메타데이터, 작성자 정보, 히어로 이미지 등 추가 정보 수집
- Backend API 개선
  - Scrap 엔티티에 새로운 메타데이터 필드 추가 (JSONB 형식)
  - API Version 2 엔드포인트 추가로 하위 호환성 유지
  - 기존 데이터 마이그레이션을 위한 SQL 스크립트 포함
- 데이터 구조 개선
  - content_info: 다양한 형식의 콘텐츠 저장
  - webpage: 웹페이지 메타데이터 (URL, 제목, 설명, 사이트 정보)
  - authors: 작성자 정보 배열
  - hero_image_url: 대표 이미지 URL
  - published_at: 원본 콘텐츠 발행일
  - type: 스크랩 타입 (webclip, pdf 등)
  - from_source: 스크랩 출처 (extension, api 등)

## 데이터베이스 변경사항

### 새로운 컬럼 추가
```sql
ALTER TABLE public.scraps
ADD COLUMN content_info JSONB,
ADD COLUMN webpage JSONB,
ADD COLUMN hero_image_url TEXT,
ADD COLUMN published_at TIMESTAMP WITH TIME ZONE,
ADD COLUMN authors JSONB,
ADD COLUMN type VARCHAR(50) DEFAULT 'webclip',
ADD COLUMN from_source VARCHAR(50) DEFAULT 'extension';
```
### 인덱스 추가

- idx_scraps_type: 스크랩 타입별 검색 최적화
- idx_scraps_from_source: 출처별 필터링 최적화
- idx_scraps_published_at: 발행일 기준 정렬
- GIN 인덱스: JSONB 컬럼들의 검색 성능 향상

### 기존 데이터 마이그레이션

- 기존 content → content_info.plain
- 기존 html_content → content_info.raw
- HTML에서 순수 텍스트 추출 → content_info.text
- 하위 호환성을 위해 기존 컬럼 유지

## 빌드 & 배포

### 빌드 확인

- npm run build 성공
- dist/ 폴더 정상 생성
- TypeScript 컴파일 에러 없음

### 테스트 완료

- Extension에서 웹페이지 스크랩 정상 동작
- V2 API 엔드포인트 정상 응답
- 기존 V1 API 하위 호환성 유지
- 데이터베이스 마이그레이션 스크립트 테스트
- Docker 이미지 빌드 및 실행 확인

## API 변경사항

- V2 엔드포인트 추가
  - POST /api/v2/scraps: 향상된 메타데이터 포함 스크랩 생성
  - GET /api/v2/scraps: 메타데이터 포함 스크랩 목록 조회
  - GET /api/v2/scraps/:id: 메타데이터 포함 스크랩 상세 조회

## 배포 시 주의사항

1. 데이터베이스 마이그레이션 실행 필요
2. Extension과 Backend 동시 배포 필요
3. 기존 V1 API 사용 클라이언트는 영향 없음