### PR TITLE
[CHI-388] V3 아티클 생성 스트리밍 추가

### DIFF
--- a/src/api/articles/articles.controller.ts
+++ b/src/api/articles/articles.controller.ts
@@ -10,7 +10,10 @@ import {
   Version,
   UseGuards,
   Request,
+  Sse,
+  MessageEvent,
 } from '@nestjs/common';
+import { Observable } from 'rxjs';
 import { ArticlesService } from '../../articles/articles.service';
 import { CreateArticleDto } from './dto/create-article.dto';
 import {
@@ -289,5 +292,38 @@ export class ArticlesController {
   findAllV3(@Request() req: any) {
     const userId = parseInt(req.user.id);
     return this.articlesService.findByUserV3(userId);
+  }
+
+  /**
+   * V3: AI를 사용하여 뉴스레터를 실시간 스트리밍으로 생성합니다
+   * POST /api/v3/articles/generate-stream
+   */
+  @ApiOperation({
+    summary:
+      'V3: AI를 사용하여 뉴스레터를 실시간 스트리밍으로 생성합니다 (SSE)',
+    description:
+      'Server-Sent Events를 통해 실시간으로 생성 진행 상황을 전송합니다. 각 노드의 실행 상태와 진행률을 확인할 수 있습니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '스트리밍 연결이 성공적으로 설정되었습니다.',
+  })
+  @ApiResponse({ status: 400, description: '잘못된 요청입니다.' })
+  @ApiResponse({
+    status: 404,
+    description: '사용자나 리소스를 찾을 수 없습니다.',
+  })
+  @Version('3')
+  @Post('generate-stream')
+  @Sse()
+  generateArticleV3Stream(
+    @Request() req: any,
+    @Body() generateArticleDto: GenerateArticleV3Dto,
+  ): Observable<MessageEvent> {
+    const userId = parseInt(req.user.id);
+    return this.articlesService.generateArticleV3Stream(
+      userId,
+      generateArticleDto,
+    );
   }
 }

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -21,6 +21,9 @@ import { EntityManager, EntityRepository } from '@mikro-orm/core';
 import { NewsletterAgentService } from '../agents/services/newsletter-agent.service';
 import { SlackService } from '../notifications/slack.service';
 import { WritingStyleExample } from 'src/writing-styles/entities/writing-style-example.entity';
+import { Observable } from 'rxjs';
+import { MessageEvent } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 // Analytics tracking migrated to extension client (PostHog).
 
 @Injectable()
@@ -41,6 +44,7 @@ export class ArticlesService {
     private readonly slackService: SlackService,
     @InjectRepository(WritingStyleExample)
     private readonly writingStyleExampleRepository: EntityRepository<WritingStyleExample>,
+    private readonly configService: ConfigService,
     // Uploaded files are represented as scraps with file metadata
   ) {}
 
@@ -1078,5 +1082,293 @@ export class ArticlesService {
         );
       }
     }
+  }
+
+  // ========== V3 Streaming API ==========
+
+  /**
+   * V3: 실시간 스트리밍으로 아티클 생성
+   */
+  generateArticleV3Stream(
+    userId: number,
+    generateDto: GenerateArticleV3Dto,
+  ): Observable<MessageEvent> {
+    return new Observable((observer) => {
+      const agentApiUrl = this.configService.get<string>('TYQUILL_AGENT_API_URL');
+
+      // Main async function
+      (async () => {
+        let article: Article | null = null;
+
+        try {
+          this.logger.log(
+            `📡 Starting V3 streaming article generation for user ${userId}`,
+          );
+
+          // 사용자 검증
+          const user = await this.userRepository.findOne({ userId: userId });
+          if (!user) {
+            throw new NotFoundException('사용자를 찾을 수 없습니다.');
+          }
+
+          // 즉시 processing 상태로 아티클 생성
+          article = new Article();
+          article.topic = generateDto.topic;
+          article.keyInsight = generateDto.keyInsight;
+          article.generationParams = generateDto.generationParams;
+          article.generationStatus = 'processing';
+          article.user = user;
+
+          await this.em.persistAndFlush(article);
+
+          this.logger.log(
+            `✅ Article created with ID: ${article.articleId}, starting stream`,
+          );
+
+          // Prepare scrap data
+          let scrapsWithComments: Array<{
+            scrap: Scrap;
+            userComment?: string;
+          }> = [];
+
+          if (
+            generateDto.scrapWithOptionalComment &&
+            generateDto.scrapWithOptionalComment.length > 0
+          ) {
+            const scraps = await this.scrapRepository.find({
+              scrapId: {
+                $in: generateDto.scrapWithOptionalComment.map(
+                  (comment) => comment.scrapId,
+                ),
+              },
+              user: user,
+              isDeleted: false,
+            });
+
+            scrapsWithComments = scraps.map((scrap) => {
+              const scrapComment = generateDto.scrapWithOptionalComment?.find(
+                (comment) => comment.scrapId === scrap.scrapId,
+              );
+              return {
+                scrap,
+                userComment: scrapComment?.userComment,
+              };
+            });
+          }
+
+          // Prepare PDF uploads
+          let pdfUploadsWithPrompts: Array<{
+            url: string;
+            usagePrompt: string;
+            aiContent: string;
+          }> = [];
+
+          if (
+            generateDto.uploadWithUsagePrompt &&
+            generateDto.uploadWithUsagePrompt.length > 0
+          ) {
+            const uploads = generateDto.uploadWithUsagePrompt;
+            const scrapIds = uploads.map((u) => u.uploadedFileId);
+
+            const usagePromptById = new Map<number, string>();
+            for (const u of uploads)
+              usagePromptById.set(u.uploadedFileId, u.usagePrompt);
+
+            const uploadScraps = await this.scrapRepository.find({
+              scrapId: { $in: scrapIds },
+              user: user,
+              isDeleted: false,
+            });
+
+            pdfUploadsWithPrompts = uploadScraps
+              .map((scrap) => {
+                const url = scrap.filePath || scrap.url;
+                if (!url) return null;
+                return {
+                  url,
+                  usagePrompt: usagePromptById.get(scrap.scrapId) || '',
+                  aiContent: scrap.aiContent || '',
+                };
+              })
+              .filter(
+                (
+                  x,
+                ): x is { url: string; usagePrompt: string; aiContent: string } =>
+                  x !== null,
+              );
+          }
+
+          // Prepare writing style examples
+          let writingStyleExampleContents: string[] = [];
+          if (generateDto.writingStyleId) {
+            const writingStyleExamples =
+              await this.writingStyleExampleRepository.find(
+                {
+                  writingStyle: {
+                    id: generateDto.writingStyleId,
+                    user: user,
+                  },
+                },
+                { populate: ['writingStyle'] },
+              );
+            writingStyleExampleContents = writingStyleExamples.map(
+              (example) => example.content,
+            );
+          }
+
+          // Format scraps for API
+          const formattedScrapsWithComments = scrapsWithComments.map(
+            (item) => ({
+              scrap: {
+                id: item.scrap.scrapId,
+                title: item.scrap.title,
+                url: item.scrap.url,
+                content: item.scrap.content,
+                userComment: item.scrap.userComment,
+              },
+              userComment: item.userComment,
+            }),
+          );
+
+          // Call Python agent streaming endpoint
+          const response = await fetch(
+            `${agentApiUrl}/api/v1/newsletter/generate-stream`,
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                topic: generateDto.topic,
+                keyInsight: generateDto.keyInsight,
+                scrapsWithComments: formattedScrapsWithComments,
+                generationParams: generateDto.generationParams,
+                articleStructureTemplate: generateDto.articleStructureTemplate,
+                writingStyleExampleContents,
+                pdfUrlsWithPrompts: pdfUploadsWithPrompts,
+              }),
+            },
+          );
+
+          if (!response.ok) {
+            throw new Error(
+              `Python agent returned ${response.status}: ${response.statusText}`,
+            );
+          }
+
+          if (!response.body) {
+            throw new Error('Response body is null');
+          }
+
+          // Read the stream
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = '';
+
+          while (true) {
+            const { done, value } = await reader.read();
+
+            if (done) {
+              this.logger.log('📡 Stream ended');
+              break;
+            }
+
+            // Decode chunk
+            buffer += decoder.decode(value, { stream: true });
+
+            // Process complete SSE messages
+            const lines = buffer.split('\n\n');
+            buffer = lines.pop() || ''; // Keep incomplete message in buffer
+
+            for (const line of lines) {
+              if (line.startsWith('data: ')) {
+                const jsonData = line.slice(6); // Remove 'data: ' prefix
+                try {
+                  const event = JSON.parse(jsonData);
+
+                  // Forward to client
+                  observer.next({ data: event } as MessageEvent);
+
+                  // Handle complete event
+                  if (event.type === 'complete') {
+                    this.logger.log('🎉 Received complete event from agent');
+
+                    // Save results to database
+                    const archive = new ArticleArchive();
+                    archive.title = event.title;
+                    archive.content = event.content;
+                    archive.versionNumber = 1;
+                    archive.article = article;
+
+                    article.generationStatus = 'completed';
+                    await this.em.persistAndFlush([archive, article]);
+
+                    // Send Slack notification
+                    try {
+                      await this.slackService.notifyArticleGeneration({
+                        articleId: article.articleId,
+                        title: event.title,
+                        topic: generateDto.topic,
+                        keyInsight: generateDto.keyInsight,
+                        userEmail: user.email,
+                        userName: user.name,
+                        userId: user.userId,
+                        contentLength: event.content?.length,
+                        version: 'V3-Stream',
+                        createdAt: article.createdAt,
+                      });
+                    } catch (slackError) {
+                      this.logger.warn(
+                        'Failed to send Slack notification:',
+                        slackError,
+                      );
+                    }
+                  }
+
+                  // Handle error event
+                  if (event.type === 'error') {
+                    this.logger.error('❌ Error event from agent:', event.message);
+                    if (article) {
+                      article.generationStatus = 'failed';
+                      await this.em.persistAndFlush(article);
+                    }
+                  }
+                } catch (parseError) {
+                  this.logger.warn('Failed to parse SSE event:', parseError);
+                }
+              }
+            }
+          }
+
+          // Complete the observable
+          observer.complete();
+        } catch (error) {
+          this.logger.error(
+            '❌ Streaming article generation failed:',
+            error,
+          );
+
+          // Update article status to failed
+          if (article) {
+            try {
+              article.generationStatus = 'failed';
+              await this.em.persistAndFlush(article);
+            } catch (updateError) {
+              this.logger.error('Failed to update article status:', updateError);
+            }
+          }
+
+          // Send error to client
+          observer.next({
+            data: {
+              type: 'error',
+              message: error.message || 'Streaming failed',
+            },
+          } as MessageEvent);
+
+          observer.error(error);
+        }
+      })();
+    });
   }
 }


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-388](https://linear.app/chill-mato/issue/CHI-388/)

## 📋 변경사항 요약
FastAPI(Agent)와 클라이언트 사이 SSE 기반 스트리밍 구조 구현 - V3 아티클 생성 스트리밍 엔드포인트 추가

## 주요 변경사항

### 새로운 API 엔드포인트
- **POST /api/v3/articles/generate/stream**
  - Server-Sent Events (SSE) 기반 실시간 스트리밍
  - Python AI 에이전트의 스트리밍 이벤트를 클라이언트로 중계
  - `text/event-stream` Content-Type 사용

### 스트리밍 이벤트 구조
- **progress**: 진행률 및 현재 단계 메시지 (이중 언어 지원)
- **node_start**: 워크플로우 노드 시작 이벤트
- **node_complete**: 워크플로우 노드 완료 이벤트
- **complete**: 최종 완료 이벤트 (title, content 포함)
- **error**: 에러 발생 시 에러 정보
- **heartbeat**: 연결 유지를 위한 keep-alive

### 하위 호환성 유지
- 기존 POST /api/v3/articles/generate (동기식) 엔드포인트 유지
- 클라이언트는 필요에 따라 동기식/스트리밍 방식 선택 가능

### 구현 상세
- AI 에이전트의 `/api/v1/newsletter/generate-stream` 엔드포인트 호출
- SSE 형식으로 이벤트 중계 (`data: {json}\n\n`)
- 에러 처리 및 스트림 종료 처리 구현

### 변경된 파일
- `src/api/articles/articles.controller.ts`: 스트리밍 엔드포인트 추가
- `src/articles/articles.service.ts`: 스트리밍 서비스 로직 구현

## 🗃️ 데이터베이스 변경사항
없음

## 📦 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음

## 기타 참고사항
- Python AI 에이전트(CHI-389)와 프론트엔드(CHI-387) 작업과 함께 배포 필요
- AI 에이전트의 스트리밍 API가 정상 동작해야 정상 작동