### PR TITLE
[CHI-395] 아티클 버전관리 api 추가

### DIFF
--- a/src/api/articles/articles.controller.ts
+++ b/src/api/articles/articles.controller.ts
@@ -148,6 +148,35 @@ export class ArticlesController {
   }
 
   /**
+   * 아티클 버전 히스토리 조회
+   * GET /api/v1/articles/:id/versions
+   */
+  @Version('1')
+  @Get(':id/versions')
+  @ApiOperation({ summary: '아티클의 모든 버전 목록을 조회합니다' })
+  @ApiResponse({ status: 200, description: '버전 목록 조회 성공' })
+  @ApiResponse({ status: 404, description: '아티클을 찾을 수 없습니다' })
+  getVersions(@Param('id') id: string) {
+    return this.articlesService.getVersions(+id);
+  }
+
+  /**
+   * 특정 버전으로 복원
+   * POST /api/v1/articles/:id/restore/:versionNumber
+   */
+  @Version('1')
+  @Post(':id/restore/:versionNumber')
+  @ApiOperation({ summary: '아티클을 특정 버전으로 복원합니다' })
+  @ApiResponse({ status: 200, description: '버전 복원 성공' })
+  @ApiResponse({ status: 404, description: '아티클 또는 버전을 찾을 수 없습니다' })
+  restoreVersion(
+    @Param('id') id: string,
+    @Param('versionNumber') versionNumber: string,
+  ) {
+    return this.articlesService.restoreVersion(+id, +versionNumber);
+  }
+
+  /**
    * 배치 아티클 삭제
    * DELETE /api/v1/articles/batch
    */

--- a/src/api/articles/articles.controller.ts
+++ b/src/api/articles/articles.controller.ts
@@ -12,6 +12,7 @@ import {
   Request,
   Sse,
   MessageEvent,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { ArticlesService } from '../../articles/articles.service';
@@ -155,9 +156,15 @@ export class ArticlesController {
   @Get(':id/versions')
   @ApiOperation({ summary: '아티클의 모든 버전 목록을 조회합니다' })
   @ApiResponse({ status: 200, description: '버전 목록 조회 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 요청입니다' })
+  @ApiResponse({ status: 403, description: '권한이 없습니다' })
   @ApiResponse({ status: 404, description: '아티클을 찾을 수 없습니다' })
-  getVersions(@Param('id') id: string) {
-    return this.articlesService.getVersions(+id);
+  getVersions(
+    @Request() req: any,
+    @Param('id', ParseIntPipe) id: number,
+  ) {
+    const userId = parseInt(req.user.id);
+    return this.articlesService.getVersions(id, userId);
   }
 
   /**
@@ -168,12 +175,16 @@ export class ArticlesController {
   @Post(':id/restore/:versionNumber')
   @ApiOperation({ summary: '아티클을 특정 버전으로 복원합니다' })
   @ApiResponse({ status: 200, description: '버전 복원 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 요청입니다' })
+  @ApiResponse({ status: 403, description: '권한이 없습니다' })
   @ApiResponse({ status: 404, description: '아티클 또는 버전을 찾을 수 없습니다' })
   restoreVersion(
-    @Param('id') id: string,
-    @Param('versionNumber') versionNumber: string,
+    @Request() req: any,
+    @Param('id', ParseIntPipe) id: number,
+    @Param('versionNumber', ParseIntPipe) versionNumber: number,
   ) {
-    return this.articlesService.restoreVersion(+id, +versionNumber);
+    const userId = parseInt(req.user.id);
+    return this.articlesService.restoreVersion(id, versionNumber, userId);
   }
 
   /**

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, NotFoundException, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
 import { CreateArticleDto } from '../api/articles/dto/create-article.dto';
 import {
   GenerateArticleDto,
@@ -17,7 +23,7 @@ import { Article } from './entities/article.entity';
 import { ArticleArchive } from '../article-archive/entities/article-archive.entity';
 import { Scrap } from '../scraps/entities/scrap.entity';
 import { User } from '../users/entities/user.entity';
-import { EntityManager, EntityRepository } from '@mikro-orm/core';
+import { EntityManager, EntityRepository, LockMode } from '@mikro-orm/core';
 import { NewsletterAgentService } from '../agents/services/newsletter-agent.service';
 import { SlackService } from '../notifications/slack.service';
 import { WritingStyleExample } from 'src/writing-styles/entities/writing-style-example.entity';
@@ -478,14 +484,23 @@ export class ArticlesService {
   /**
    * 아티클 버전 히스토리 조회
    */
-  async getVersions(articleId: number): Promise<any[]> {
+  async getVersions(articleId: number, userId: number): Promise<any[]> {
+    this.logger.log(
+      `📋 Fetching versions for article ${articleId} by user ${userId}`,
+    );
+
     const article = await this.articleRepository.findOne(
       { articleId, isDeleted: false },
-      { populate: ['archives'] },
+      { populate: ['archives', 'user'] },
     );
 
     if (!article) {
       throw new NotFoundException('아티클을 찾을 수 없습니다.');
+    }
+
+    // 권한 검증
+    if (article.user.userId !== userId) {
+      throw new ForbiddenException('이 아티클에 접근할 권한이 없습니다.');
     }
 
     // 모든 아카이브 버전을 버전 번호 역순으로 정렬 (최신 버전이 먼저)
@@ -502,60 +517,97 @@ export class ArticlesService {
         characterCount: archive.content?.length || 0,
       }));
 
+    this.logger.log(
+      `✅ Retrieved ${versions.length} versions for article ${articleId}`,
+    );
+
     return versions;
   }
 
   /**
    * 특정 버전으로 복원
    */
-  async restoreVersion(articleId: number, versionNumber: number): Promise<any> {
-    const article = await this.articleRepository.findOne(
-      { articleId, isDeleted: false },
-      { populate: ['archives'] },
-    );
-
-    if (!article) {
-      throw new NotFoundException('아티클을 찾을 수 없습니다.');
-    }
-
-    // 복원할 버전 찾기
-    const targetVersion = article.archives
-      .getItems()
-      .find(
-        (archive) =>
-          archive.versionNumber === versionNumber && !archive.isDeleted,
-      );
-
-    if (!targetVersion) {
-      throw new NotFoundException(
-        `버전 ${versionNumber}을(를) 찾을 수 없습니다.`,
-      );
-    }
-
-    // 최신 버전 번호 확인
-    const latestArchive = await this.em.findOne(
-      ArticleArchive,
-      { article: article, isDeleted: false },
-      { orderBy: { versionNumber: 'desc' }, filters: { isDeleted: false } },
-    );
-
-    // 새 버전 생성 (복원된 내용으로)
-    const newVersionNumber = (latestArchive?.versionNumber || 0) + 1;
-    const newArchive = new ArticleArchive();
-    newArchive.title = targetVersion.title;
-    newArchive.content = targetVersion.content;
-    newArchive.contentFormat = targetVersion.contentFormat || 'markdown';
-    newArchive.versionNumber = newVersionNumber;
-    newArchive.article = article;
-
-    await this.em.persistAndFlush(newArchive);
-
+  async restoreVersion(
+    articleId: number,
+    versionNumber: number,
+    userId: number,
+  ): Promise<any> {
     this.logger.log(
-      `✅ Version ${versionNumber} restored as new version ${newVersionNumber}`,
+      `🔄 Restoring article ${articleId} to version ${versionNumber} by user ${userId}`,
     );
 
-    // 복원된 아티클 정보 반환
-    return this.findOne(articleId);
+    // 입력 검증
+    if (versionNumber < 1) {
+      throw new BadRequestException('버전 번호는 1 이상이어야 합니다.');
+    }
+
+    // 트랜잭션 및 락을 사용하여 동시성 문제 방지
+    return await this.em.transactional(async (em) => {
+      // PESSIMISTIC_WRITE 락으로 아티클 조회
+      const article = await em.findOne(
+        Article,
+        { articleId, isDeleted: false },
+        {
+          populate: ['archives', 'user'],
+          lockMode: LockMode.PESSIMISTIC_WRITE,
+        },
+      );
+
+      if (!article) {
+        throw new NotFoundException('아티클을 찾을 수 없습니다.');
+      }
+
+      // 권한 검증
+      if (article.user.userId !== userId) {
+        throw new ForbiddenException('이 아티클을 수정할 권한이 없습니다.');
+      }
+
+      // 복원할 버전 찾기
+      const targetVersion = article.archives
+        .getItems()
+        .find(
+          (archive) =>
+            archive.versionNumber === versionNumber && !archive.isDeleted,
+        );
+
+      if (!targetVersion) {
+        throw new NotFoundException(
+          `버전 ${versionNumber}을(를) 찾을 수 없습니다.`,
+        );
+      }
+
+      // 이미 로드된 archives에서 최신 버전 번호 계산 (중복 쿼리 제거)
+      const latestVersionNumber = Math.max(
+        ...article.archives
+          .getItems()
+          .filter((a) => !a.isDeleted)
+          .map((a) => a.versionNumber || 0),
+        0,
+      );
+
+      // 최신 버전 복원 시도 검증
+      if (versionNumber === latestVersionNumber) {
+        throw new BadRequestException('이미 최신 버전입니다.');
+      }
+
+      // 새 버전 생성 (복원된 내용으로)
+      const newVersionNumber = latestVersionNumber + 1;
+      const newArchive = new ArticleArchive();
+      newArchive.title = targetVersion.title;
+      newArchive.content = targetVersion.content;
+      newArchive.contentFormat = targetVersion.contentFormat || 'markdown';
+      newArchive.versionNumber = newVersionNumber;
+      newArchive.article = article;
+
+      await em.persistAndFlush(newArchive);
+
+      this.logger.log(
+        `✅ Version ${versionNumber} restored as new version ${newVersionNumber}`,
+      );
+
+      // 복원된 아티클 정보 반환
+      return this.findOne(articleId);
+    });
   }
 
   /**

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -476,6 +476,89 @@ export class ArticlesService {
   }
 
   /**
+   * 아티클 버전 히스토리 조회
+   */
+  async getVersions(articleId: number): Promise<any[]> {
+    const article = await this.articleRepository.findOne(
+      { articleId, isDeleted: false },
+      { populate: ['archives'] },
+    );
+
+    if (!article) {
+      throw new NotFoundException('아티클을 찾을 수 없습니다.');
+    }
+
+    // 모든 아카이브 버전을 버전 번호 역순으로 정렬 (최신 버전이 먼저)
+    const versions = article.archives
+      .getItems()
+      .filter((archive) => !archive.isDeleted)
+      .sort((a, b) => (b.versionNumber || 0) - (a.versionNumber || 0))
+      .map((archive) => ({
+        versionNumber: archive.versionNumber,
+        title: archive.title,
+        content: archive.content,
+        contentFormat: archive.contentFormat || 'markdown',
+        createdAt: archive.createdAt,
+        characterCount: archive.content?.length || 0,
+      }));
+
+    return versions;
+  }
+
+  /**
+   * 특정 버전으로 복원
+   */
+  async restoreVersion(articleId: number, versionNumber: number): Promise<any> {
+    const article = await this.articleRepository.findOne(
+      { articleId, isDeleted: false },
+      { populate: ['archives'] },
+    );
+
+    if (!article) {
+      throw new NotFoundException('아티클을 찾을 수 없습니다.');
+    }
+
+    // 복원할 버전 찾기
+    const targetVersion = article.archives
+      .getItems()
+      .find(
+        (archive) =>
+          archive.versionNumber === versionNumber && !archive.isDeleted,
+      );
+
+    if (!targetVersion) {
+      throw new NotFoundException(
+        `버전 ${versionNumber}을(를) 찾을 수 없습니다.`,
+      );
+    }
+
+    // 최신 버전 번호 확인
+    const latestArchive = await this.em.findOne(
+      ArticleArchive,
+      { article: article, isDeleted: false },
+      { orderBy: { versionNumber: 'desc' }, filters: { isDeleted: false } },
+    );
+
+    // 새 버전 생성 (복원된 내용으로)
+    const newVersionNumber = (latestArchive?.versionNumber || 0) + 1;
+    const newArchive = new ArticleArchive();
+    newArchive.title = targetVersion.title;
+    newArchive.content = targetVersion.content;
+    newArchive.contentFormat = targetVersion.contentFormat || 'markdown';
+    newArchive.versionNumber = newVersionNumber;
+    newArchive.article = article;
+
+    await this.em.persistAndFlush(newArchive);
+
+    this.logger.log(
+      `✅ Version ${versionNumber} restored as new version ${newVersionNumber}`,
+    );
+
+    // 복원된 아티클 정보 반환
+    return this.findOne(articleId);
+  }
+
+  /**
    * 아티클 검색
    */
   async search(query: string, userId?: number): Promise<Article[]> {


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-395](https://linear.app/chill-mato/issue/CHI-395)

## 변경사항 요약
전체화면 에디터의 버전 히스토리 기능을 위한 백엔드 API 엔드포인트를 추가

### API 엔드포인트 추가
- `GET /api/v1/articles/:id/versions`: 아티클의 모든 버전 목록 조회
- `POST /api/v1/articles/:id/restore/:versionNumber`: 특정 버전을 새 버전으로 복원

### 주요 기능
1. **버전 목록 조회** (`getVersions`)
   - 삭제되지 않은 버전만 필터링
   - 버전 번호 역순 정렬 (최신 버전 먼저)
   - 반환 데이터: versionNumber, title, content, contentFormat, createdAt, characterCount

2. **버전 복원** (`restoreVersion`)
   - 복원할 버전 검색 및 검증
   - 최신 버전 번호 확인 후 +1하여 새 버전 생성
   - 기존 버전들은 모두 유지 (히스토리 보존)
   - 복원된 아티클 전체 정보 반환

## 데이터베이스 변경사항
- 없음 (기존 ArticleArchive 테이블 활용)

## 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음