### PR TITLE
[CHI-402] 폴더 구조 및 통합 콘텐츠 뷰

### DIFF
--- a/src/api/articles/articles.controller.ts
+++ b/src/api/articles/articles.controller.ts
@@ -159,10 +159,7 @@ export class ArticlesController {
   @ApiResponse({ status: 400, description: '잘못된 요청입니다' })
   @ApiResponse({ status: 403, description: '권한이 없습니다' })
   @ApiResponse({ status: 404, description: '아티클을 찾을 수 없습니다' })
-  getVersions(
-    @Request() req: any,
-    @Param('id', ParseIntPipe) id: number,
-  ) {
+  getVersions(@Request() req: any, @Param('id', ParseIntPipe) id: number) {
     const userId = parseInt(req.user.id);
     return this.articlesService.getVersions(id, userId);
   }
@@ -177,7 +174,10 @@ export class ArticlesController {
   @ApiResponse({ status: 200, description: '버전 복원 성공' })
   @ApiResponse({ status: 400, description: '잘못된 요청입니다' })
   @ApiResponse({ status: 403, description: '권한이 없습니다' })
-  @ApiResponse({ status: 404, description: '아티클 또는 버전을 찾을 수 없습니다' })
+  @ApiResponse({
+    status: 404,
+    description: '아티클 또는 버전을 찾을 수 없습니다',
+  })
   restoreVersion(
     @Request() req: any,
     @Param('id', ParseIntPipe) id: number,

--- a/src/api/content/content.controller.ts
+++ b/src/api/content/content.controller.ts
@@ -8,7 +8,12 @@ import {
   HttpException,
   HttpStatus,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { ContentService } from '../../content/content.service';
 import { UnifiedContentQueryDto } from './dto/unified-content-query.dto';

--- a/src/api/content/content.controller.ts
+++ b/src/api/content/content.controller.ts
@@ -1,0 +1,93 @@
+import {
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+  Request,
+  Version,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { ContentService } from '../../content/content.service';
+import { UnifiedContentQueryDto } from './dto/unified-content-query.dto';
+import { UnifiedContentResponseDto } from './dto/unified-content-response.dto';
+
+@ApiTags('content')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('content')
+export class ContentController {
+  constructor(private readonly contentService: ContentService) {}
+
+  /**
+   * GET /api/v1/content/unified - Get unified content (scraps and articles)
+   *
+   * This endpoint provides a unified view of both scraps and articles with:
+   * - Pagination support
+   * - Flexible filtering (by folder, type, tags)
+   * - Search across titles and content
+   * - Sorting by multiple fields
+   *
+   * Query Parameters:
+   * - folderId: Filter by folder (null for root items, omit for all)
+   * - type: Filter by content type (scrap, article, or all)
+   * - scrapType: Sub-filter for scraps (webclip or upload)
+   * - page: Page number (default: 1)
+   * - limit: Items per page (default: 20, max: 100)
+   * - sortBy: Field to sort by (createdAt, updatedAt, title)
+   * - sortOrder: Sort direction (ASC or DESC)
+   * - search: Search in title and content
+   * - tags: Filter by tag names (OR logic)
+   *
+   * Example Usage:
+   * - Get all content: GET /api/v1/content/unified
+   * - Get only scraps: GET /api/v1/content/unified?type=scrap
+   * - Get folder contents: GET /api/v1/content/unified?folderId=abc-123
+   * - Search content: GET /api/v1/content/unified?search=typescript
+   * - Filter by tags: GET /api/v1/content/unified?tags=javascript&tags=tutorial
+   */
+  @Version('1')
+  @Get('unified')
+  @ApiOperation({
+    summary: 'Get unified content (scraps and articles)',
+    description:
+      'Retrieve a paginated list of scraps and/or articles with flexible filtering, search, and sorting options',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Unified content retrieved successfully',
+    type: UnifiedContentResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - invalid query parameters',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - invalid or missing JWT token',
+  })
+  async getUnifiedContent(
+    @Query() query: UnifiedContentQueryDto,
+    @Request() req: any,
+  ): Promise<UnifiedContentResponseDto> {
+    try {
+      const userId = parseInt(req.user.id);
+
+      return await this.contentService.getUnifiedContent(userId, query);
+    } catch (error: any) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
+      // Log the error for debugging
+      console.error('Error fetching unified content:', error);
+
+      throw new HttpException(
+        error.message || 'Failed to fetch unified content',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+}

--- a/src/api/content/dto/unified-content-query.dto.ts
+++ b/src/api/content/dto/unified-content-query.dto.ts
@@ -1,0 +1,112 @@
+import { IsOptional, IsString, IsInt, Min, Max, IsEnum, IsArray } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export enum ContentType {
+  SCRAP = 'scrap',
+  ARTICLE = 'article',
+  ALL = 'all',
+}
+
+export enum ScrapSubType {
+  WEBCLIP = 'webclip',
+  UPLOAD = 'upload',
+}
+
+export enum SortByField {
+  CREATED_AT = 'createdAt',
+  UPDATED_AT = 'updatedAt',
+  TITLE = 'title',
+}
+
+export enum SortOrder {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
+
+export class UnifiedContentQueryDto {
+  @ApiPropertyOptional({
+    description: 'Filter by folder ID (null for root items, omit for all items)',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsOptional()
+  @IsString()
+  folderId?: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Filter by content type',
+    enum: ContentType,
+    default: ContentType.ALL,
+  })
+  @IsOptional()
+  @IsEnum(ContentType)
+  type?: ContentType = ContentType.ALL;
+
+  @ApiPropertyOptional({
+    description: 'Sub-filter for scraps only (webclip or upload)',
+    enum: ScrapSubType,
+  })
+  @IsOptional()
+  @IsEnum(ScrapSubType)
+  scrapType?: ScrapSubType;
+
+  @ApiPropertyOptional({
+    description: 'Page number (1-indexed)',
+    minimum: 1,
+    default: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Number of items per page',
+    minimum: 1,
+    maximum: 100,
+    default: 20,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({
+    description: 'Field to sort by',
+    enum: SortByField,
+    default: SortByField.CREATED_AT,
+  })
+  @IsOptional()
+  @IsEnum(SortByField)
+  sortBy?: SortByField = SortByField.CREATED_AT;
+
+  @ApiPropertyOptional({
+    description: 'Sort order',
+    enum: SortOrder,
+    default: SortOrder.DESC,
+  })
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sortOrder?: SortOrder = SortOrder.DESC;
+
+  @ApiPropertyOptional({
+    description: 'Search query (searches in title and content)',
+    example: 'typescript tutorial',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by tag names (OR logic - items with any of these tags)',
+    type: [String],
+    example: ['javascript', 'tutorial'],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+}

--- a/src/api/content/dto/unified-content-query.dto.ts
+++ b/src/api/content/dto/unified-content-query.dto.ts
@@ -1,4 +1,12 @@
-import { IsOptional, IsString, IsInt, Min, Max, IsEnum, IsArray } from 'class-validator';
+import {
+  IsOptional,
+  IsString,
+  IsInt,
+  Min,
+  Max,
+  IsEnum,
+  IsArray,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
@@ -26,7 +34,8 @@ export enum SortOrder {
 
 export class UnifiedContentQueryDto {
   @ApiPropertyOptional({
-    description: 'Filter by folder ID (null for root items, omit for all items)',
+    description:
+      'Filter by folder ID (null for root items, omit for all items)',
     example: '550e8400-e29b-41d4-a716-446655440000',
   })
   @IsOptional()
@@ -101,7 +110,8 @@ export class UnifiedContentQueryDto {
   search?: string;
 
   @ApiPropertyOptional({
-    description: 'Filter by tag names (OR logic - items with any of these tags)',
+    description:
+      'Filter by tag names (OR logic - items with any of these tags)',
     type: [String],
     example: ['javascript', 'tutorial'],
   })

--- a/src/api/content/dto/unified-content-response.dto.ts
+++ b/src/api/content/dto/unified-content-response.dto.ts
@@ -1,0 +1,135 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class TagDto {
+  @ApiProperty({ example: 1 })
+  tagId: number;
+
+  @ApiProperty({ example: 'javascript' })
+  name: string;
+}
+
+export class UnifiedContentItemDto {
+  @ApiProperty({
+    description: 'Unique identifier (scrapId or articleId as string)',
+    example: '123',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Type of content',
+    enum: ['scrap', 'article'],
+    example: 'scrap',
+  })
+  type: 'scrap' | 'article';
+
+  @ApiProperty({ example: 'Introduction to TypeScript' })
+  title: string;
+
+  @ApiProperty({
+    description: 'Preview of content (first 200 characters)',
+    example: 'TypeScript is a typed superset of JavaScript...',
+  })
+  contentPreview: string;
+
+  @ApiProperty({ example: '2025-10-19T10:30:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: '2025-10-19T12:45:00.000Z' })
+  updatedAt: Date;
+
+  @ApiPropertyOptional({
+    description: 'Folder ID if item is in a folder',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  folderId?: string;
+
+  // Scrap-specific fields
+  @ApiPropertyOptional({
+    description: 'URL of the scraped content (scrap only)',
+    example: 'https://example.com/article',
+  })
+  url?: string;
+
+  @ApiPropertyOptional({
+    description: 'Type of scrap (scrap only)',
+    enum: ['webclip', 'pdf', 'image', 'video', 'audio', 'upload'],
+    example: 'webclip',
+  })
+  scrapType?: 'webclip' | 'pdf' | 'image' | 'video' | 'audio' | 'upload';
+
+  @ApiPropertyOptional({
+    description: 'Hero image URL (scrap only)',
+    example: 'https://example.com/hero.jpg',
+  })
+  heroImageUrl?: string;
+
+  @ApiPropertyOptional({
+    description: 'Favicon URL (scrap only)',
+    example: 'https://example.com/favicon.ico',
+  })
+  faviconUrl?: string;
+
+  @ApiPropertyOptional({
+    description: 'Tags associated with the scrap (scrap only)',
+    type: [TagDto],
+  })
+  tags?: TagDto[];
+
+  // Article-specific fields
+  @ApiPropertyOptional({
+    description: 'Article topic (article only)',
+    example: 'Web Development Best Practices',
+  })
+  topic?: string;
+
+  @ApiPropertyOptional({
+    description: 'Key insight of the article (article only)',
+    example: 'TypeScript provides type safety for JavaScript projects',
+  })
+  keyInsight?: string;
+
+  @ApiPropertyOptional({
+    description: 'Generation status (article only)',
+    enum: ['processing', 'completed', 'failed'],
+    example: 'completed',
+  })
+  generationStatus?: string;
+}
+
+export class UnifiedContentResponseDto {
+  @ApiProperty({
+    description: 'Array of unified content items',
+    type: [UnifiedContentItemDto],
+  })
+  items: UnifiedContentItemDto[];
+
+  @ApiProperty({
+    description: 'Total number of items matching the query',
+    example: 150,
+  })
+  total: number;
+
+  @ApiProperty({
+    description: 'Current page number',
+    example: 1,
+  })
+  page: number;
+
+  @ApiProperty({
+    description: 'Number of items per page',
+    example: 20,
+  })
+  limit: number;
+
+  @ApiProperty({
+    description: 'Whether there are more items to load',
+    example: true,
+  })
+  hasMore: boolean;
+
+  @ApiProperty({
+    description: 'Total number of pages',
+    example: 8,
+  })
+  totalPages: number;
+}

--- a/src/api/folders/dto/create-folder.dto.ts
+++ b/src/api/folders/dto/create-folder.dto.ts
@@ -1,9 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsOptional, IsUUID } from 'class-validator';
+import { IsString, IsOptional, IsUUID, Length, Matches } from 'class-validator';
 
 export class CreateFolderDto {
   @ApiProperty({ description: 'Folder name', example: 'My Research' })
   @IsString()
+  @Length(1, 255, {
+    message: 'Folder name must be between 1 and 255 characters',
+  })
+  // eslint-disable-next-line no-control-regex
+  @Matches(/^[^<>:"/\\|?*\x00-\x1F]+$/, {
+    message:
+      'Folder name contains invalid characters (no <, >, :, ", /, \\, |, ?, *, or control characters)',
+  })
   name: string;
 
   @ApiProperty({
@@ -13,6 +21,7 @@ export class CreateFolderDto {
   })
   @IsOptional()
   @IsString()
+  @Length(0, 1000, { message: 'Description must not exceed 1000 characters' })
   description?: string;
 
   @ApiProperty({
@@ -22,6 +31,9 @@ export class CreateFolderDto {
   })
   @IsOptional()
   @IsString()
+  @Matches(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/, {
+    message: 'Color must be a valid hex code (e.g., #3B82F6 or #F00)',
+  })
   color?: string;
 
   @ApiProperty({
@@ -31,6 +43,11 @@ export class CreateFolderDto {
   })
   @IsOptional()
   @IsString()
+  @Length(1, 100, { message: 'Icon name must be between 1 and 100 characters' })
+  @Matches(/^[a-zA-Z0-9_-]+$/, {
+    message:
+      'Icon name can only contain letters, numbers, hyphens, and underscores',
+  })
   icon?: string;
 
   @ApiProperty({
@@ -39,6 +56,6 @@ export class CreateFolderDto {
     example: '550e8400-e29b-41d4-a716-446655440000',
   })
   @IsOptional()
-  @IsUUID()
+  @IsUUID(4, { message: 'Parent folder ID must be a valid UUID v4' })
   parentFolderId?: string;
 }

--- a/src/api/folders/dto/create-folder.dto.ts
+++ b/src/api/folders/dto/create-folder.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional, IsUUID } from 'class-validator';
+
+export class CreateFolderDto {
+  @ApiProperty({ description: 'Folder name', example: 'My Research' })
+  @IsString()
+  name: string;
+
+  @ApiProperty({
+    description: 'Folder description',
+    required: false,
+    example: 'Collection of research materials',
+  })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({
+    description: 'Folder color for UI (hex code)',
+    required: false,
+    example: '#3B82F6',
+  })
+  @IsOptional()
+  @IsString()
+  color?: string;
+
+  @ApiProperty({
+    description: 'Folder icon name',
+    required: false,
+    example: 'folder',
+  })
+  @IsOptional()
+  @IsString()
+  icon?: string;
+
+  @ApiProperty({
+    description: 'Parent folder UUID for nested structure',
+    required: false,
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsOptional()
+  @IsUUID()
+  parentFolderId?: string;
+}

--- a/src/api/folders/dto/folder-response.dto.ts
+++ b/src/api/folders/dto/folder-response.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FolderResponseDto {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  folderId: string;
+
+  @ApiProperty({ example: 'My Research' })
+  name: string;
+
+  @ApiProperty({ example: 'Collection of research materials', nullable: true })
+  description?: string;
+
+  @ApiProperty({ example: '#3B82F6', nullable: true })
+  color?: string;
+
+  @ApiProperty({ example: 'folder', nullable: true })
+  icon?: string;
+
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000', nullable: true })
+  parentFolderId?: string;
+
+  @ApiProperty({ example: false })
+  isDeleted: boolean;
+
+  @ApiProperty({ example: '2025-10-19T00:00:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: '2025-10-19T00:00:00.000Z' })
+  updatedAt: Date;
+
+  @ApiProperty({ type: 'number', example: 5 })
+  scrapCount?: number;
+
+  @ApiProperty({ type: 'number', example: 2 })
+  articleCount?: number;
+
+  @ApiProperty({ type: 'number', example: 3 })
+  childFolderCount?: number;
+}
+
+export class FolderContentsDto {
+  @ApiProperty({ type: FolderResponseDto })
+  folder: FolderResponseDto;
+
+  @ApiProperty({ type: 'array', description: 'Scraps in this folder' })
+  scraps: any[];
+
+  @ApiProperty({ type: 'array', description: 'Articles in this folder' })
+  articles: any[];
+
+  @ApiProperty({ type: [FolderResponseDto], description: 'Child folders' })
+  childFolders: FolderResponseDto[];
+}

--- a/src/api/folders/dto/folder-response.dto.ts
+++ b/src/api/folders/dto/folder-response.dto.ts
@@ -16,7 +16,10 @@ export class FolderResponseDto {
   @ApiProperty({ example: 'folder', nullable: true })
   icon?: string;
 
-  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000', nullable: true })
+  @ApiProperty({
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    nullable: true,
+  })
   parentFolderId?: string;
 
   @ApiProperty({ example: false })

--- a/src/api/folders/dto/move-folder-items.dto.ts
+++ b/src/api/folders/dto/move-folder-items.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsInt, IsOptional, IsUUID } from 'class-validator';
+
+export class MoveFolderItemsDto {
+  @ApiProperty({
+    description: 'Array of scrap IDs to move to this folder',
+    required: false,
+    example: [1, 2, 3],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsInt({ each: true })
+  scrapIds?: number[];
+
+  @ApiProperty({
+    description: 'Array of article IDs to move to this folder',
+    required: false,
+    example: [10, 20, 30],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsInt({ each: true })
+  articleIds?: number[];
+
+  @ApiProperty({
+    description: 'Target folder UUID (null to remove from folder)',
+    required: false,
+    nullable: true,
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsOptional()
+  @IsUUID()
+  targetFolderId?: string | null;
+}

--- a/src/api/folders/dto/update-folder.dto.ts
+++ b/src/api/folders/dto/update-folder.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateFolderDto } from './create-folder.dto';
+
+export class UpdateFolderDto extends PartialType(CreateFolderDto) {}

--- a/src/api/folders/folders.controller.ts
+++ b/src/api/folders/folders.controller.ts
@@ -1,0 +1,243 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Version,
+  Query,
+  HttpException,
+  HttpStatus,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { FoldersService } from '../../folders/folders.service';
+import { CreateFolderDto } from './dto/create-folder.dto';
+import { UpdateFolderDto } from './dto/update-folder.dto';
+import { MoveFolderItemsDto } from './dto/move-folder-items.dto';
+import {
+  FolderResponseDto,
+  FolderContentsDto,
+} from './dto/folder-response.dto';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+
+@ApiTags('folders')
+@UseGuards(JwtAuthGuard)
+@Controller('folders')
+export class FoldersController {
+  constructor(private readonly foldersService: FoldersService) {}
+
+  /**
+   * POST /api/v1/folders - Create a new folder
+   */
+  @Version('1')
+  @Post()
+  @ApiOperation({ summary: 'Create a new folder' })
+  @ApiResponse({
+    status: 201,
+    description: 'Folder created successfully',
+    type: FolderResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Bad request' })
+  @ApiResponse({ status: 404, description: 'Parent folder not found' })
+  async create(
+    @Body() createFolderDto: CreateFolderDto,
+    @Request() req: any,
+  ): Promise<FolderResponseDto> {
+    try {
+      const userId = parseInt(req.user.id);
+      return await this.foldersService.create(userId, createFolderDto);
+    } catch (error: any) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  /**
+   * GET /api/v1/folders - Get all folders for current user
+   * Query params:
+   * - parentId: Filter by parent folder (null for root folders)
+   */
+  @Version('1')
+  @Get()
+  @ApiOperation({ summary: 'Get all folders for current user' })
+  @ApiResponse({
+    status: 200,
+    description: 'Folders retrieved successfully',
+    type: [FolderResponseDto],
+  })
+  async findAll(
+    @Request() req: any,
+    @Query('parentId') parentId?: string,
+  ): Promise<FolderResponseDto[]> {
+    try {
+      const userId = parseInt(req.user.id);
+
+      // Convert 'null' string to actual null for root folders
+      const parentFolderId =
+        parentId === 'null' ? null : parentId || undefined;
+
+      return await this.foldersService.findAll(userId, parentFolderId);
+    } catch (error: any) {
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * GET /api/v1/folders/:id - Get a specific folder by ID
+   */
+  @Version('1')
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a specific folder by ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Folder retrieved successfully',
+    type: FolderResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Folder not found' })
+  async findOne(
+    @Param('id') id: string,
+    @Request() req: any,
+  ): Promise<FolderResponseDto> {
+    try {
+      const userId = parseInt(req.user.id);
+      return await this.foldersService.findOne(id, userId);
+    } catch (error: any) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * PATCH /api/v1/folders/:id - Update a folder
+   */
+  @Version('1')
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update a folder' })
+  @ApiResponse({
+    status: 200,
+    description: 'Folder updated successfully',
+    type: FolderResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Bad request' })
+  @ApiResponse({ status: 404, description: 'Folder not found' })
+  async update(
+    @Param('id') id: string,
+    @Body() updateFolderDto: UpdateFolderDto,
+    @Request() req: any,
+  ): Promise<FolderResponseDto> {
+    try {
+      const userId = parseInt(req.user.id);
+      return await this.foldersService.update(id, userId, updateFolderDto);
+    } catch (error: any) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  /**
+   * DELETE /api/v1/folders/:id - Soft delete a folder
+   */
+  @Version('1')
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a folder (soft delete)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Folder deleted successfully',
+  })
+  @ApiResponse({ status: 400, description: 'Cannot delete folder with children' })
+  @ApiResponse({ status: 404, description: 'Folder not found' })
+  async remove(@Param('id') id: string, @Request() req: any) {
+    try {
+      const userId = parseInt(req.user.id);
+      await this.foldersService.remove(id, userId);
+      return { message: 'Folder deleted successfully' };
+    } catch (error: any) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * POST /api/v1/folders/:id/items - Move scraps/articles to a folder
+   * POST /api/v1/folders/items (with targetFolderId: null) - Remove items from folder
+   */
+  @Version('1')
+  @Post(':id/items')
+  @ApiOperation({ summary: 'Move scraps/articles to a folder' })
+  @ApiResponse({
+    status: 200,
+    description: 'Items moved successfully',
+  })
+  @ApiResponse({ status: 404, description: 'Folder not found' })
+  async moveItems(
+    @Param('id') id: string,
+    @Body() moveFolderItemsDto: MoveFolderItemsDto,
+    @Request() req: any,
+  ) {
+    try {
+      const userId = parseInt(req.user.id);
+
+      // Use targetFolderId from DTO if provided, otherwise use URL param
+      const targetFolderId =
+        moveFolderItemsDto.targetFolderId !== undefined
+          ? moveFolderItemsDto.targetFolderId
+          : id;
+
+      const result = await this.foldersService.moveItemsToFolder(
+        targetFolderId,
+        userId,
+        moveFolderItemsDto.scrapIds,
+        moveFolderItemsDto.articleIds,
+      );
+
+      return {
+        message: 'Items moved successfully',
+        ...result,
+      };
+    } catch (error: any) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  /**
+   * GET /api/v1/folders/:id/contents - Get folder contents (scraps, articles, child folders)
+   */
+  @Version('1')
+  @Get(':id/contents')
+  @ApiOperation({ summary: 'Get folder contents' })
+  @ApiResponse({
+    status: 200,
+    description: 'Folder contents retrieved successfully',
+    type: FolderContentsDto,
+  })
+  @ApiResponse({ status: 404, description: 'Folder not found' })
+  async getFolderContents(
+    @Param('id') id: string,
+    @Request() req: any,
+  ): Promise<FolderContentsDto> {
+    try {
+      const userId = parseInt(req.user.id);
+      return await this.foldersService.getFolderContents(id, userId);
+    } catch (error: any) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/src/api/folders/folders.controller.ts
+++ b/src/api/folders/folders.controller.ts
@@ -79,8 +79,7 @@ export class FoldersController {
       const userId = parseInt(req.user.id);
 
       // Convert 'null' string to actual null for root folders
-      const parentFolderId =
-        parentId === 'null' ? null : parentId || undefined;
+      const parentFolderId = parentId === 'null' ? null : parentId || undefined;
 
       return await this.foldersService.findAll(userId, parentFolderId);
     } catch (error: any) {
@@ -154,7 +153,10 @@ export class FoldersController {
     status: 200,
     description: 'Folder deleted successfully',
   })
-  @ApiResponse({ status: 400, description: 'Cannot delete folder with children' })
+  @ApiResponse({
+    status: 400,
+    description: 'Cannot delete folder with children',
+  })
   @ApiResponse({ status: 404, description: 'Folder not found' })
   async remove(@Param('id') id: string, @Request() req: any) {
     try {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,8 @@ import { UploadedFilesModule } from './uploaded-files/uploaded-files.module';
 import { LibraryItemsModule } from './library-items/library-items.module';
 import { QueueModule } from './queue/queue.module';
 import { AdminModule } from './api/admin/admin.module';
+import { FoldersModule } from './folders/folders.module';
+import { ContentModule } from './content/content.module';
 
 @Module({
   imports: [
@@ -31,6 +33,8 @@ import { AdminModule } from './api/admin/admin.module';
     WritingStylesModule,
     UploadedFilesModule,
     LibraryItemsModule,
+    FoldersModule, // 폴더 모듈 추가
+    ContentModule, // 통합 콘텐츠 모듈 추가
     QueueModule, // SQS 큐 모듈 추가
     AdminModule, // 관리자 모듈 추가
   ],

--- a/src/article-archive/entities/article-archive.entity.ts
+++ b/src/article-archive/entities/article-archive.entity.ts
@@ -12,7 +12,12 @@ export class ArticleArchive {
   @Property({ fieldName: 'content', type: 'text' })
   content!: string;
 
-  @Property({ fieldName: 'content_format', type: 'varchar', length: 20, default: 'markdown' })
+  @Property({
+    fieldName: 'content_format',
+    type: 'varchar',
+    length: 20,
+    default: 'markdown',
+  })
   contentFormat: 'markdown' | 'tiptap-json' = 'markdown';
 
   @Property({ fieldName: 'version_number', type: 'int', nullable: true })

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -543,12 +543,11 @@ export class ArticlesService {
 
     // 트랜잭션 및 락을 사용하여 동시성 문제 방지
     return await this.em.transactional(async (em) => {
-      // PESSIMISTIC_WRITE 락으로 아티클 조회
+      // Article만 PESSIMISTIC_WRITE 락으로 조회 (populate 없이)
       const article = await em.findOne(
         Article,
         { articleId, isDeleted: false },
         {
-          populate: ['archives', 'user'],
           lockMode: LockMode.PESSIMISTIC_WRITE,
         },
       );
@@ -557,10 +556,15 @@ export class ArticlesService {
         throw new NotFoundException('아티클을 찾을 수 없습니다.');
       }
 
-      // 권한 검증
+      // 권한 검증을 위해 user 별도 조회
+      await em.populate(article, ['user']);
+
       if (article.user.userId !== userId) {
         throw new ForbiddenException('이 아티클을 수정할 권한이 없습니다.');
       }
+
+      // archives 별도 조회
+      await em.populate(article, ['archives']);
 
       // 복원할 버전 찾기
       const targetVersion = article.archives

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -1233,7 +1233,9 @@ export class ArticlesService {
     generateDto: GenerateArticleV3Dto,
   ): Observable<MessageEvent> {
     return new Observable((observer) => {
-      const agentApiUrl = this.configService.get<string>('TYQUILL_AGENT_API_URL');
+      const agentApiUrl = this.configService.get<string>(
+        'TYQUILL_AGENT_API_URL',
+      );
 
       // Main async function
       (async () => {
@@ -1332,8 +1334,11 @@ export class ArticlesService {
               .filter(
                 (
                   x,
-                ): x is { url: string; usagePrompt: string; aiContent: string } =>
-                  x !== null,
+                ): x is {
+                  url: string;
+                  usagePrompt: string;
+                  aiContent: string;
+                } => x !== null,
               );
           }
 
@@ -1466,7 +1471,10 @@ export class ArticlesService {
 
                   // Handle error event
                   if (event.type === 'error') {
-                    this.logger.error('❌ Error event from agent:', event.message);
+                    this.logger.error(
+                      '❌ Error event from agent:',
+                      event.message,
+                    );
                     if (article) {
                       article.generationStatus = 'failed';
                       await this.em.persistAndFlush(article);
@@ -1482,10 +1490,7 @@ export class ArticlesService {
           // Complete the observable
           observer.complete();
         } catch (error) {
-          this.logger.error(
-            '❌ Streaming article generation failed:',
-            error,
-          );
+          this.logger.error('❌ Streaming article generation failed:', error);
 
           // Update article status to failed
           if (article) {
@@ -1493,7 +1498,10 @@ export class ArticlesService {
               article.generationStatus = 'failed';
               await this.em.persistAndFlush(article);
             } catch (updateError) {
-              this.logger.error('Failed to update article status:', updateError);
+              this.logger.error(
+                'Failed to update article status:',
+                updateError,
+              );
             }
           }
 

--- a/src/articles/entities/article.entity.ts
+++ b/src/articles/entities/article.entity.ts
@@ -10,6 +10,7 @@ import { CreateArticleDto } from '../../api/articles/dto/create-article.dto';
 import { ArticleArchive } from '../../article-archive/entities/article-archive.entity';
 import { User } from '../../users/entities/user.entity';
 import { Scrap } from '../../scraps/entities/scrap.entity';
+import { Folder } from '../../folders/entities/folder.entity';
 
 @Entity({ tableName: 'articles' })
 export class Article {
@@ -50,6 +51,12 @@ export class Article {
 
   @OneToMany(() => Scrap, (scrap) => scrap.article)
   scraps = new Collection<Scrap>(this);
+
+  @ManyToOne(() => Folder, {
+    fieldName: 'folder_id',
+    nullable: true,
+  })
+  folder?: Folder;
 
   /**
    * CreateArticleDto로부터 Article 인스턴스를 생성합니다

--- a/src/content/content.module.ts
+++ b/src/content/content.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { ContentService } from './content.service';
+import { ContentController } from '../api/content/content.controller';
+import { Scrap } from '../scraps/entities/scrap.entity';
+import { Article } from '../articles/entities/article.entity';
+import { User } from '../users/entities/user.entity';
+
+@Module({
+  imports: [
+    MikroOrmModule.forFeature([Scrap, Article, User]),
+  ],
+  controllers: [ContentController],
+  providers: [ContentService],
+  exports: [ContentService],
+})
+export class ContentModule {}

--- a/src/content/content.module.ts
+++ b/src/content/content.module.ts
@@ -7,9 +7,7 @@ import { Article } from '../articles/entities/article.entity';
 import { User } from '../users/entities/user.entity';
 
 @Module({
-  imports: [
-    MikroOrmModule.forFeature([Scrap, Article, User]),
-  ],
+  imports: [MikroOrmModule.forFeature([Scrap, Article, User])],
   controllers: [ContentController],
   providers: [ContentService],
   exports: [ContentService],

--- a/src/content/content.service.ts
+++ b/src/content/content.service.ts
@@ -1,0 +1,427 @@
+import { Injectable } from '@nestjs/common';
+import { EntityManager, EntityRepository, QueryOrder } from '@mikro-orm/postgresql';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { Scrap } from '../scraps/entities/scrap.entity';
+import { Article } from '../articles/entities/article.entity';
+import {
+  UnifiedContentQueryDto,
+  ContentType,
+  SortByField,
+} from '../api/content/dto/unified-content-query.dto';
+import {
+  UnifiedContentResponseDto,
+  UnifiedContentItemDto,
+} from '../api/content/dto/unified-content-response.dto';
+
+@Injectable()
+export class ContentService {
+  constructor(
+    private readonly em: EntityManager,
+    @InjectRepository(Scrap)
+    private readonly scrapRepository: EntityRepository<Scrap>,
+    @InjectRepository(Article)
+    private readonly articleRepository: EntityRepository<Article>,
+  ) {}
+
+  /**
+   * Get unified content (scraps and articles) with pagination, filtering, and search
+   */
+  async getUnifiedContent(
+    userId: number,
+    query: UnifiedContentQueryDto,
+  ): Promise<UnifiedContentResponseDto> {
+    const { type, folderId, scrapType, search, tags } = query;
+
+    // Ensure defaults for required pagination fields
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const sortBy = query.sortBy ?? SortByField.CREATED_AT;
+    const sortOrder = query.sortOrder ?? 'DESC';
+
+    // Determine which content types to fetch
+    const includeScraps = type === ContentType.ALL || type === ContentType.SCRAP;
+    const includeArticles = type === ContentType.ALL || type === ContentType.ARTICLE;
+
+    let scraps: Scrap[] = [];
+    let scrapTotal = 0;
+    let articles: Article[] = [];
+    let articleTotal = 0;
+
+    // Fetch scraps if needed
+    if (includeScraps) {
+      const scrapResult = await this.fetchScraps(userId, {
+        folderId,
+        scrapType,
+        sortBy,
+        sortOrder,
+        search,
+        tags,
+        page,
+        limit,
+        includeArticles, // If both types, we need to merge and paginate later
+      });
+      scraps = scrapResult.items;
+      scrapTotal = scrapResult.total;
+    }
+
+    // Fetch articles if needed
+    if (includeArticles) {
+      const articleResult = await this.fetchArticles(userId, {
+        folderId,
+        sortBy,
+        sortOrder,
+        search,
+        page,
+        limit,
+        includeScraps, // If both types, we need to merge and paginate later
+      });
+      articles = articleResult.items;
+      articleTotal = articleResult.total;
+    }
+
+    // If fetching both types, we need to merge, sort, and paginate
+    if (type === ContentType.ALL) {
+      return this.mergeAndPaginateContent(
+        scraps,
+        articles,
+        scrapTotal,
+        articleTotal,
+        page,
+        limit,
+        sortBy,
+        sortOrder,
+      );
+    }
+
+    // If fetching single type, convert to DTOs
+    const items: UnifiedContentItemDto[] = [];
+    let total = 0;
+
+    if (includeScraps && !includeArticles) {
+      items.push(...scraps.map((scrap) => this.scrapToDto(scrap)));
+      total = scrapTotal;
+    } else if (includeArticles && !includeScraps) {
+      items.push(...articles.map((article) => this.articleToDto(article)));
+      total = articleTotal;
+    }
+
+    const totalPages = Math.ceil(total / limit);
+    const hasMore = page < totalPages;
+
+    return {
+      items,
+      total,
+      page,
+      limit,
+      hasMore,
+      totalPages,
+    };
+  }
+
+  /**
+   * Fetch scraps with filters
+   */
+  private async fetchScraps(
+    userId: number,
+    options: {
+      folderId?: string | null;
+      scrapType?: string;
+      sortBy: SortByField;
+      sortOrder: string;
+      search?: string;
+      tags?: string[];
+      page: number;
+      limit: number;
+      includeArticles?: boolean;
+    },
+  ): Promise<{ items: Scrap[]; total: number }> {
+    const { folderId, scrapType, sortBy, sortOrder, search, tags, page, limit, includeArticles } =
+      options;
+
+    const where: any = {
+      user: { userId },
+      isDeleted: false,
+    };
+
+    // Folder filter
+    if (folderId !== undefined) {
+      if (folderId === null || folderId === 'null') {
+        where.folder = null;
+      } else {
+        where.folder = { folderId };
+      }
+    }
+
+    // Scrap type filter (webclip vs upload)
+    if (scrapType) {
+      if (scrapType === 'webclip') {
+        where.type = 'webclip';
+      } else if (scrapType === 'upload') {
+        // Upload types: pdf, image, video, audio, upload
+        where.type = { $in: ['pdf', 'image', 'video', 'audio', 'upload'] };
+      }
+    }
+
+    // Search filter (title or content)
+    if (search) {
+      where.$or = [
+        { title: { $ilike: `%${search}%` } },
+        { content: { $ilike: `%${search}%` } },
+      ];
+    }
+
+    // Tag filter (scraps with any of the specified tags)
+    if (tags && tags.length > 0) {
+      where.tags = { name: { $in: tags } };
+    }
+
+    // Get total count
+    const total = await this.scrapRepository.count(where);
+
+    // If we're fetching both scraps and articles, we need all items for proper sorting
+    // Otherwise, paginate at database level
+    const offset = includeArticles ? 0 : (page - 1) * limit;
+    const fetchLimit = includeArticles ? undefined : limit;
+
+    // Determine sort field and order
+    const orderBy = this.getSortField(sortBy, 'scrap');
+    const order = sortOrder === 'ASC' ? QueryOrder.ASC : QueryOrder.DESC;
+
+    // Fetch scraps with tags populated
+    const items = await this.scrapRepository.find(where, {
+      populate: ['tags'],
+      orderBy: { [orderBy]: order },
+      offset,
+      limit: fetchLimit,
+    });
+
+    return { items, total };
+  }
+
+  /**
+   * Fetch articles with filters
+   */
+  private async fetchArticles(
+    userId: number,
+    options: {
+      folderId?: string | null;
+      sortBy: SortByField;
+      sortOrder: string;
+      search?: string;
+      page: number;
+      limit: number;
+      includeScraps?: boolean;
+    },
+  ): Promise<{ items: Article[]; total: number }> {
+    const { folderId, sortBy, sortOrder, search, page, limit, includeScraps } = options;
+
+    const where: any = {
+      user: { userId },
+      isDeleted: false,
+    };
+
+    // Folder filter
+    if (folderId !== undefined) {
+      if (folderId === null || folderId === 'null') {
+        where.folder = null;
+      } else {
+        where.folder = { folderId };
+      }
+    }
+
+    // Search filter (title or content from latest archive)
+    if (search) {
+      // Note: Searching article content requires joining with archives
+      // For simplicity, we'll search in topic and keyInsight
+      where.$or = [
+        { topic: { $ilike: `%${search}%` } },
+        { keyInsight: { $ilike: `%${search}%` } },
+      ];
+    }
+
+    // Get total count
+    const total = await this.articleRepository.count(where);
+
+    // If we're fetching both scraps and articles, we need all items for proper sorting
+    // Otherwise, paginate at database level
+    const offset = includeScraps ? 0 : (page - 1) * limit;
+    const fetchLimit = includeScraps ? undefined : limit;
+
+    // Determine sort field and order
+    const orderBy = this.getSortField(sortBy, 'article');
+    const order = sortOrder === 'ASC' ? QueryOrder.ASC : QueryOrder.DESC;
+
+    // Fetch articles with archives populated
+    const items = await this.articleRepository.find(where, {
+      populate: ['archives'],
+      orderBy: { [orderBy]: order },
+      offset,
+      limit: fetchLimit,
+    });
+
+    return { items, total };
+  }
+
+  /**
+   * Merge scraps and articles, sort, and paginate
+   */
+  private mergeAndPaginateContent(
+    scraps: Scrap[],
+    articles: Article[],
+    scrapTotal: number,
+    articleTotal: number,
+    page: number,
+    limit: number,
+    sortBy: SortByField,
+    sortOrder: string,
+  ): UnifiedContentResponseDto {
+    // Convert to DTOs
+    const scrapDtos = scraps.map((scrap) => this.scrapToDto(scrap));
+    const articleDtos = articles.map((article) => this.articleToDto(article));
+
+    // Merge all items
+    const allItems = [...scrapDtos, ...articleDtos];
+
+    // Sort by the specified field
+    allItems.sort((a, b) => {
+      let aValue: any;
+      let bValue: any;
+
+      if (sortBy === SortByField.CREATED_AT) {
+        aValue = new Date(a.createdAt).getTime();
+        bValue = new Date(b.createdAt).getTime();
+      } else if (sortBy === SortByField.UPDATED_AT) {
+        aValue = new Date(a.updatedAt).getTime();
+        bValue = new Date(b.updatedAt).getTime();
+      } else if (sortBy === SortByField.TITLE) {
+        aValue = a.title.toLowerCase();
+        bValue = b.title.toLowerCase();
+      }
+
+      if (sortOrder === 'ASC') {
+        return aValue < bValue ? -1 : aValue > bValue ? 1 : 0;
+      } else {
+        return aValue > bValue ? -1 : aValue < bValue ? 1 : 0;
+      }
+    });
+
+    // Paginate
+    const total = scrapTotal + articleTotal;
+    const totalPages = Math.ceil(total / limit);
+    const startIndex = (page - 1) * limit;
+    const endIndex = startIndex + limit;
+    const items = allItems.slice(startIndex, endIndex);
+    const hasMore = page < totalPages;
+
+    return {
+      items,
+      total,
+      page,
+      limit,
+      hasMore,
+      totalPages,
+    };
+  }
+
+  /**
+   * Convert Scrap entity to UnifiedContentItemDto
+   */
+  private scrapToDto(scrap: Scrap): UnifiedContentItemDto {
+    // Get content preview (first 200 characters)
+    let contentPreview = scrap.content || '';
+    if (contentPreview.length > 200) {
+      contentPreview = contentPreview.substring(0, 200) + '...';
+    }
+
+    return {
+      id: scrap.scrapId.toString(),
+      type: 'scrap',
+      title: scrap.title,
+      contentPreview,
+      createdAt: scrap.createdAt,
+      updatedAt: scrap.updatedAt,
+      folderId: scrap.folder?.folderId,
+      url: scrap.url,
+      scrapType: scrap.type as any,
+      heroImageUrl: scrap.heroImageUrl,
+      faviconUrl: scrap.webpage?.site?.favicon_url,
+      tags: scrap.tags?.getItems().map((tag) => ({
+        tagId: tag.tagId,
+        name: tag.name,
+      })),
+    };
+  }
+
+  /**
+   * Convert Article entity to UnifiedContentItemDto
+   */
+  private articleToDto(article: Article): UnifiedContentItemDto {
+    // Get content preview from latest archive
+    const latestContent = article.getLatestContent() || '';
+    let contentPreview = latestContent;
+
+    // If content is TipTap JSON, extract text
+    if (contentPreview.trim().startsWith('{')) {
+      try {
+        const json = JSON.parse(contentPreview);
+        // Extract plain text from TipTap JSON (simplified)
+        contentPreview = this.extractTextFromTipTap(json);
+      } catch {
+        // If parsing fails, use as-is
+      }
+    }
+
+    // Limit to 200 characters
+    if (contentPreview.length > 200) {
+      contentPreview = contentPreview.substring(0, 200) + '...';
+    }
+
+    return {
+      id: article.articleId.toString(),
+      type: 'article',
+      title: article.getLatestTitle() || 'Untitled',
+      contentPreview,
+      createdAt: article.createdAt,
+      updatedAt: article.updatedAt,
+      folderId: article.folder?.folderId,
+      topic: article.topic,
+      keyInsight: article.keyInsight,
+      generationStatus: article.generationStatus,
+    };
+  }
+
+  /**
+   * Extract plain text from TipTap JSON (simplified)
+   */
+  private extractTextFromTipTap(json: any): string {
+    if (!json || typeof json !== 'object') return '';
+
+    let text = '';
+
+    if (json.text) {
+      text += json.text;
+    }
+
+    if (json.content && Array.isArray(json.content)) {
+      for (const node of json.content) {
+        text += this.extractTextFromTipTap(node) + ' ';
+      }
+    }
+
+    return text.trim();
+  }
+
+  /**
+   * Get database field name for sorting
+   */
+  private getSortField(sortBy: SortByField, entityType: 'scrap' | 'article'): string {
+    if (sortBy === SortByField.CREATED_AT) {
+      return 'createdAt';
+    } else if (sortBy === SortByField.UPDATED_AT) {
+      return 'updatedAt';
+    } else if (sortBy === SortByField.TITLE) {
+      return 'title';
+    }
+    return 'createdAt'; // Default
+  }
+}

--- a/src/content/content.service.ts
+++ b/src/content/content.service.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { EntityManager, EntityRepository, QueryOrder } from '@mikro-orm/postgresql';
+import {
+  EntityManager,
+  EntityRepository,
+  QueryOrder,
+} from '@mikro-orm/postgresql';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { Scrap } from '../scraps/entities/scrap.entity';
 import { Article } from '../articles/entities/article.entity';
@@ -15,6 +19,9 @@ import {
 
 @Injectable()
 export class ContentService {
+  // Safety limit to prevent OOM when fetching both content types
+  private readonly MAX_IN_MEMORY_ITEMS = 1000;
+
   constructor(
     private readonly em: EntityManager,
     @InjectRepository(Scrap)
@@ -39,8 +46,10 @@ export class ContentService {
     const sortOrder = query.sortOrder ?? 'DESC';
 
     // Determine which content types to fetch
-    const includeScraps = type === ContentType.ALL || type === ContentType.SCRAP;
-    const includeArticles = type === ContentType.ALL || type === ContentType.ARTICLE;
+    const includeScraps =
+      type === ContentType.ALL || type === ContentType.SCRAP;
+    const includeArticles =
+      type === ContentType.ALL || type === ContentType.ARTICLE;
 
     let scraps: Scrap[] = [];
     let scrapTotal = 0;
@@ -135,8 +144,17 @@ export class ContentService {
       includeArticles?: boolean;
     },
   ): Promise<{ items: Scrap[]; total: number }> {
-    const { folderId, scrapType, sortBy, sortOrder, search, tags, page, limit, includeArticles } =
-      options;
+    const {
+      folderId,
+      scrapType,
+      sortBy,
+      sortOrder,
+      search,
+      tags,
+      page,
+      limit,
+      includeArticles,
+    } = options;
 
     const where: any = {
       user: { userId },
@@ -178,10 +196,20 @@ export class ContentService {
     // Get total count
     const total = await this.scrapRepository.count(where);
 
-    // If we're fetching both scraps and articles, we need all items for proper sorting
-    // Otherwise, paginate at database level
+    // Set hard limit when fetching both types to prevent memory issues
+    // When includeArticles=true, we need more items for proper sorting, but not unlimited
     const offset = includeArticles ? 0 : (page - 1) * limit;
-    const fetchLimit = includeArticles ? undefined : limit;
+    const fetchLimit = includeArticles
+      ? Math.min(this.MAX_IN_MEMORY_ITEMS, limit * 2) // Fetch 2x limit for better merge results
+      : limit;
+
+    // Warn if we're hitting the safety limit
+    if (includeArticles && total > this.MAX_IN_MEMORY_ITEMS) {
+      console.warn(
+        `[ContentService] Scrap total (${total}) exceeds MAX_IN_MEMORY_ITEMS (${this.MAX_IN_MEMORY_ITEMS}). ` +
+          `Results may be incomplete for unified content view. Consider adding folder filters.`,
+      );
+    }
 
     // Determine sort field and order
     const orderBy = this.getSortField(sortBy, 'scrap');
@@ -213,7 +241,8 @@ export class ContentService {
       includeScraps?: boolean;
     },
   ): Promise<{ items: Article[]; total: number }> {
-    const { folderId, sortBy, sortOrder, search, page, limit, includeScraps } = options;
+    const { folderId, sortBy, sortOrder, search, page, limit, includeScraps } =
+      options;
 
     const where: any = {
       user: { userId },
@@ -242,10 +271,20 @@ export class ContentService {
     // Get total count
     const total = await this.articleRepository.count(where);
 
-    // If we're fetching both scraps and articles, we need all items for proper sorting
-    // Otherwise, paginate at database level
+    // Set hard limit when fetching both types to prevent memory issues
+    // When includeScraps=true, we need more items for proper sorting, but not unlimited
     const offset = includeScraps ? 0 : (page - 1) * limit;
-    const fetchLimit = includeScraps ? undefined : limit;
+    const fetchLimit = includeScraps
+      ? Math.min(this.MAX_IN_MEMORY_ITEMS, limit * 2) // Fetch 2x limit for better merge results
+      : limit;
+
+    // Warn if we're hitting the safety limit
+    if (includeScraps && total > this.MAX_IN_MEMORY_ITEMS) {
+      console.warn(
+        `[ContentService] Article total (${total}) exceeds MAX_IN_MEMORY_ITEMS (${this.MAX_IN_MEMORY_ITEMS}). ` +
+          `Results may be incomplete for unified content view. Consider adding folder filters.`,
+      );
+    }
 
     // Determine sort field and order
     const orderBy = this.getSortField(sortBy, 'article');
@@ -414,7 +453,10 @@ export class ContentService {
   /**
    * Get database field name for sorting
    */
-  private getSortField(sortBy: SortByField, entityType: 'scrap' | 'article'): string {
+  private getSortField(
+    sortBy: SortByField,
+    entityType: 'scrap' | 'article',
+  ): string {
     if (sortBy === SortByField.CREATED_AT) {
       return 'createdAt';
     } else if (sortBy === SortByField.UPDATED_AT) {

--- a/src/folders/entities/folder.entity.ts
+++ b/src/folders/entities/folder.entity.ts
@@ -1,0 +1,88 @@
+import {
+  Collection,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+} from '@mikro-orm/core';
+import { v4 as uuidv4 } from 'uuid';
+import { User } from '../../users/entities/user.entity';
+import { Scrap } from '../../scraps/entities/scrap.entity';
+import { Article } from '../../articles/entities/article.entity';
+
+@Entity({ tableName: 'folders' })
+export class Folder {
+  @PrimaryKey({ name: 'folder_id', type: 'uuid' })
+  folderId: string = uuidv4();
+
+  @Property({ name: 'name', type: 'varchar', length: 255 })
+  name: string;
+
+  @Property({ name: 'description', type: 'text', nullable: true })
+  description?: string;
+
+  @Property({ name: 'color', type: 'varchar', length: 50, nullable: true })
+  color?: string;
+
+  @Property({ name: 'icon', type: 'varchar', length: 100, nullable: true })
+  icon?: string;
+
+  @Property({ name: 'is_deleted', type: 'boolean', default: false })
+  isDeleted: boolean = false;
+
+  @Property({ name: 'created_at' })
+  createdAt: Date = new Date();
+
+  @Property({ name: 'updated_at', onUpdate: () => new Date() })
+  updatedAt: Date = new Date();
+
+  @ManyToOne(() => User, { fieldName: 'user_id' })
+  user: User;
+
+  @ManyToOne(() => Folder, {
+    fieldName: 'parent_folder_id',
+    nullable: true,
+  })
+  parentFolder?: Folder;
+
+  @OneToMany(() => Folder, (folder) => folder.parentFolder)
+  childFolders = new Collection<Folder>(this);
+
+  @OneToMany(() => Scrap, (scrap) => scrap.folder)
+  scraps = new Collection<Scrap>(this);
+
+  @OneToMany(() => Article, (article) => article.folder)
+  articles = new Collection<Article>(this);
+
+  /**
+   * Get the full path of folder names from root to current folder
+   */
+  getPath(): string[] {
+    const path: string[] = [this.name];
+    let current = this.parentFolder;
+
+    while (current) {
+      path.unshift(current.name);
+      current = current.parentFolder;
+    }
+
+    return path;
+  }
+
+  /**
+   * Check if this folder is a descendant of the given folder
+   */
+  isDescendantOf(folder: Folder): boolean {
+    let current = this.parentFolder;
+
+    while (current) {
+      if (current.folderId === folder.folderId) {
+        return true;
+      }
+      current = current.parentFolder;
+    }
+
+    return false;
+  }
+}

--- a/src/folders/folders.module.ts
+++ b/src/folders/folders.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { Folder } from './entities/folder.entity';
+import { FoldersService } from './folders.service';
+import { FoldersController } from '../api/folders/folders.controller';
+import { User } from '../users/entities/user.entity';
+import { Scrap } from '../scraps/entities/scrap.entity';
+import { Article } from '../articles/entities/article.entity';
+
+@Module({
+  imports: [MikroOrmModule.forFeature([Folder, User, Scrap, Article])],
+  controllers: [FoldersController],
+  providers: [FoldersService],
+  exports: [FoldersService],
+})
+export class FoldersModule {}

--- a/src/folders/folders.service.ts
+++ b/src/folders/folders.service.ts
@@ -205,55 +205,67 @@ export class FoldersService {
 
   /**
    * Soft delete a folder
+   * CRITICAL FIX: Wrapped in transaction to prevent race conditions
    */
   async remove(folderId: string, userId: number): Promise<void> {
-    const folder = await this.folderRepository.findOne(
-      {
-        folderId,
-        user: { userId },
-        isDeleted: false,
-      },
-      {
-        populate: ['childFolders', 'scraps', 'articles'],
-      },
-    );
-
-    if (!folder) {
-      throw new NotFoundException('Folder not found');
-    }
-
-    // Check if folder has children
-    if (folder.childFolders.length > 0) {
-      throw new BadRequestException(
-        'Cannot delete folder with subfolders. Delete or move subfolders first.',
+    await this.em.transactional(async (em) => {
+      // Find folder within transaction
+      const folder = await em.findOne(
+        Folder,
+        {
+          folderId,
+          user: { userId },
+          isDeleted: false,
+        },
+        {
+          populate: ['childFolders', 'scraps', 'articles'],
+        },
       );
-    }
 
-    // Remove folder reference from all scraps and articles
-    const scraps = await this.scrapRepository.find({
-      folder: { folderId },
-      isDeleted: false,
-    });
-    scraps.forEach((scrap) => {
-      scrap.folder = undefined;
-    });
+      if (!folder) {
+        throw new NotFoundException('Folder not found');
+      }
 
-    const articles = await this.articleRepository.find({
-      folder: { folderId },
-      isDeleted: false,
-    });
-    articles.forEach((article) => {
-      article.folder = undefined;
-    });
+      // Re-check child count inside transaction to prevent race conditions
+      const childCount = await em.count(Folder, {
+        parentFolder: { folderId },
+        isDeleted: false,
+      });
 
-    // Soft delete the folder
-    folder.isDeleted = true;
+      if (childCount > 0) {
+        throw new BadRequestException(
+          'Cannot delete folder with subfolders. Delete or move subfolders first.',
+        );
+      }
 
-    await this.em.persistAndFlush([folder, ...scraps, ...articles]);
+      // Remove folder reference from all scraps and articles
+      const scraps = await em.find(Scrap, {
+        folder: { folderId },
+        isDeleted: false,
+      });
+      scraps.forEach((scrap) => {
+        scrap.folder = undefined;
+      });
+
+      const articles = await em.find(Article, {
+        folder: { folderId },
+        isDeleted: false,
+      });
+      articles.forEach((article) => {
+        article.folder = undefined;
+      });
+
+      // Soft delete the folder
+      folder.isDeleted = true;
+
+      // Persist all changes within transaction
+      await em.persistAndFlush([folder, ...scraps, ...articles]);
+    });
   }
 
   /**
    * Move scraps and/or articles to a folder
+   * CRITICAL FIX: Wrapped in transaction for atomicity
    */
   async moveItemsToFolder(
     folderId: string | null,
@@ -261,57 +273,59 @@ export class FoldersService {
     scrapIds?: number[],
     articleIds?: number[],
   ): Promise<{ movedScraps: number; movedArticles: number }> {
-    let targetFolder: Folder | null = null;
+    return await this.em.transactional(async (em) => {
+      let targetFolder: Folder | null = null;
 
-    // If folderId is provided, verify it exists and belongs to user
-    if (folderId) {
-      targetFolder = await this.folderRepository.findOne({
-        folderId,
-        user: { userId },
-        isDeleted: false,
-      });
+      // If folderId is provided, verify it exists and belongs to user
+      if (folderId) {
+        targetFolder = await em.findOne(Folder, {
+          folderId,
+          user: { userId },
+          isDeleted: false,
+        });
 
-      if (!targetFolder) {
-        throw new NotFoundException('Target folder not found');
+        if (!targetFolder) {
+          throw new NotFoundException('Target folder not found');
+        }
       }
-    }
 
-    let movedScraps = 0;
-    let movedArticles = 0;
+      let movedScraps = 0;
+      let movedArticles = 0;
 
-    // Move scraps
-    if (scrapIds && scrapIds.length > 0) {
-      const scraps = await this.scrapRepository.find({
-        scrapId: { $in: scrapIds },
-        user: { userId },
-        isDeleted: false,
-      });
+      // Move scraps
+      if (scrapIds && scrapIds.length > 0) {
+        const scraps = await em.find(Scrap, {
+          scrapId: { $in: scrapIds },
+          user: { userId },
+          isDeleted: false,
+        });
 
-      scraps.forEach((scrap) => {
-        scrap.folder = targetFolder || undefined;
-      });
+        scraps.forEach((scrap) => {
+          scrap.folder = targetFolder || undefined;
+        });
 
-      movedScraps = scraps.length;
-      await this.em.persistAndFlush(scraps);
-    }
+        movedScraps = scraps.length;
+        await em.persistAndFlush(scraps);
+      }
 
-    // Move articles
-    if (articleIds && articleIds.length > 0) {
-      const articles = await this.articleRepository.find({
-        articleId: { $in: articleIds },
-        user: { userId },
-        isDeleted: false,
-      });
+      // Move articles
+      if (articleIds && articleIds.length > 0) {
+        const articles = await em.find(Article, {
+          articleId: { $in: articleIds },
+          user: { userId },
+          isDeleted: false,
+        });
 
-      articles.forEach((article) => {
-        article.folder = targetFolder || undefined;
-      });
+        articles.forEach((article) => {
+          article.folder = targetFolder || undefined;
+        });
 
-      movedArticles = articles.length;
-      await this.em.persistAndFlush(articles);
-    }
+        movedArticles = articles.length;
+        await em.persistAndFlush(articles);
+      }
 
-    return { movedScraps, movedArticles };
+      return { movedScraps, movedArticles };
+    });
   }
 
   /**
@@ -409,14 +423,26 @@ export class FoldersService {
 
   /**
    * Convert Folder entity to FolderResponseDto
+   * CRITICAL FIX: Use count() instead of loadItems() to avoid N+1 queries
    */
   private async toFolderResponseDto(
     folder: Folder,
   ): Promise<FolderResponseDto> {
-    // Ensure collections are initialized
-    await folder.scraps.loadItems();
-    await folder.articles.loadItems();
-    await folder.childFolders.loadItems();
+    // Use count queries instead of loading all items (prevents N+1 and memory issues)
+    const scrapCount = await this.em.count(Scrap, {
+      folder: { folderId: folder.folderId },
+      isDeleted: false,
+    });
+
+    const articleCount = await this.em.count(Article, {
+      folder: { folderId: folder.folderId },
+      isDeleted: false,
+    });
+
+    const childFolderCount = await this.em.count(Folder, {
+      parentFolder: { folderId: folder.folderId },
+      isDeleted: false,
+    });
 
     return {
       folderId: folder.folderId,
@@ -428,12 +454,9 @@ export class FoldersService {
       isDeleted: folder.isDeleted,
       createdAt: folder.createdAt,
       updatedAt: folder.updatedAt,
-      scrapCount: folder.scraps.getItems().filter((s) => !s.isDeleted).length,
-      articleCount: folder.articles.getItems().filter((a) => !a.isDeleted)
-        .length,
-      childFolderCount: folder.childFolders
-        .getItems()
-        .filter((f) => !f.isDeleted).length,
+      scrapCount,
+      articleCount,
+      childFolderCount,
     };
   }
 }

--- a/src/folders/folders.service.ts
+++ b/src/folders/folders.service.ts
@@ -1,0 +1,439 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { Folder } from './entities/folder.entity';
+import { User } from '../users/entities/user.entity';
+import { Scrap } from '../scraps/entities/scrap.entity';
+import { Article } from '../articles/entities/article.entity';
+import { CreateFolderDto } from '../api/folders/dto/create-folder.dto';
+import { UpdateFolderDto } from '../api/folders/dto/update-folder.dto';
+import {
+  FolderResponseDto,
+  FolderContentsDto,
+} from '../api/folders/dto/folder-response.dto';
+
+@Injectable()
+export class FoldersService {
+  constructor(
+    private readonly em: EntityManager,
+    @InjectRepository(Folder)
+    private readonly folderRepository: EntityRepository<Folder>,
+    @InjectRepository(User)
+    private readonly userRepository: EntityRepository<User>,
+    @InjectRepository(Scrap)
+    private readonly scrapRepository: EntityRepository<Scrap>,
+    @InjectRepository(Article)
+    private readonly articleRepository: EntityRepository<Article>,
+  ) {}
+
+  /**
+   * Create a new folder
+   */
+  async create(
+    userId: number,
+    createFolderDto: CreateFolderDto,
+  ): Promise<FolderResponseDto> {
+    const user = await this.userRepository.findOne({ userId });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Check if parent folder exists and belongs to user
+    if (createFolderDto.parentFolderId) {
+      const parentFolder = await this.folderRepository.findOne({
+        folderId: createFolderDto.parentFolderId,
+        user: { userId },
+        isDeleted: false,
+      });
+
+      if (!parentFolder) {
+        throw new NotFoundException('Parent folder not found');
+      }
+    }
+
+    const folder = new Folder();
+    folder.name = createFolderDto.name;
+    folder.description = createFolderDto.description;
+    folder.color = createFolderDto.color;
+    folder.icon = createFolderDto.icon;
+    folder.user = user;
+
+    if (createFolderDto.parentFolderId) {
+      const parentRef = await this.folderRepository.findOne({
+        folderId: createFolderDto.parentFolderId,
+      });
+      if (parentRef) {
+        folder.parentFolder = parentRef;
+      }
+    }
+
+    await this.em.persistAndFlush(folder);
+
+    return this.toFolderResponseDto(folder);
+  }
+
+  /**
+   * Find all folders for a user
+   * Optionally filter by parent folder (for nested structure)
+   */
+  async findAll(
+    userId: number,
+    parentFolderId?: string | null,
+  ): Promise<FolderResponseDto[]> {
+    const query: any = {
+      user: { userId },
+      isDeleted: false,
+    };
+
+    // If parentFolderId is explicitly null, find root folders
+    if (parentFolderId === null) {
+      query.parentFolder = null;
+    } else if (parentFolderId) {
+      // If parentFolderId is provided, find children of that folder
+      query.parentFolder = { folderId: parentFolderId };
+    }
+    // If parentFolderId is undefined, return all folders
+
+    const folders = await this.folderRepository.find(query, {
+      populate: ['childFolders', 'scraps', 'articles'],
+      orderBy: { name: 'ASC' },
+    });
+
+    return Promise.all(
+      folders.map((folder) => this.toFolderResponseDto(folder)),
+    );
+  }
+
+  /**
+   * Find a single folder by ID
+   */
+  async findOne(folderId: string, userId: number): Promise<FolderResponseDto> {
+    const folder = await this.folderRepository.findOne(
+      {
+        folderId,
+        user: { userId },
+        isDeleted: false,
+      },
+      {
+        populate: ['childFolders', 'scraps', 'articles', 'parentFolder'],
+      },
+    );
+
+    if (!folder) {
+      throw new NotFoundException('Folder not found');
+    }
+
+    return this.toFolderResponseDto(folder);
+  }
+
+  /**
+   * Update a folder
+   */
+  async update(
+    folderId: string,
+    userId: number,
+    updateFolderDto: UpdateFolderDto,
+  ): Promise<FolderResponseDto> {
+    const folder = await this.folderRepository.findOne(
+      {
+        folderId,
+        user: { userId },
+        isDeleted: false,
+      },
+      {
+        populate: ['parentFolder'],
+      },
+    );
+
+    if (!folder) {
+      throw new NotFoundException('Folder not found');
+    }
+
+    // Check if trying to set parent folder
+    if (updateFolderDto.parentFolderId !== undefined) {
+      if (updateFolderDto.parentFolderId === null) {
+        // Moving to root
+        folder.parentFolder = undefined;
+      } else if (updateFolderDto.parentFolderId === folderId) {
+        throw new BadRequestException('Folder cannot be its own parent');
+      } else {
+        // Check if parent folder exists and belongs to user
+        const parentFolder = await this.folderRepository.findOne({
+          folderId: updateFolderDto.parentFolderId,
+          user: { userId },
+          isDeleted: false,
+        });
+
+        if (!parentFolder) {
+          throw new NotFoundException('Parent folder not found');
+        }
+
+        // Check for circular reference
+        if (parentFolder.isDescendantOf(folder)) {
+          throw new BadRequestException(
+            'Cannot move folder to its own descendant',
+          );
+        }
+
+        folder.parentFolder = parentFolder;
+      }
+    }
+
+    // Update other fields
+    if (updateFolderDto.name !== undefined) {
+      folder.name = updateFolderDto.name;
+    }
+    if (updateFolderDto.description !== undefined) {
+      folder.description = updateFolderDto.description;
+    }
+    if (updateFolderDto.color !== undefined) {
+      folder.color = updateFolderDto.color;
+    }
+    if (updateFolderDto.icon !== undefined) {
+      folder.icon = updateFolderDto.icon;
+    }
+
+    await this.em.persistAndFlush(folder);
+
+    return this.toFolderResponseDto(folder);
+  }
+
+  /**
+   * Soft delete a folder
+   */
+  async remove(folderId: string, userId: number): Promise<void> {
+    const folder = await this.folderRepository.findOne(
+      {
+        folderId,
+        user: { userId },
+        isDeleted: false,
+      },
+      {
+        populate: ['childFolders', 'scraps', 'articles'],
+      },
+    );
+
+    if (!folder) {
+      throw new NotFoundException('Folder not found');
+    }
+
+    // Check if folder has children
+    if (folder.childFolders.length > 0) {
+      throw new BadRequestException(
+        'Cannot delete folder with subfolders. Delete or move subfolders first.',
+      );
+    }
+
+    // Remove folder reference from all scraps and articles
+    const scraps = await this.scrapRepository.find({
+      folder: { folderId },
+      isDeleted: false,
+    });
+    scraps.forEach((scrap) => {
+      scrap.folder = undefined;
+    });
+
+    const articles = await this.articleRepository.find({
+      folder: { folderId },
+      isDeleted: false,
+    });
+    articles.forEach((article) => {
+      article.folder = undefined;
+    });
+
+    // Soft delete the folder
+    folder.isDeleted = true;
+
+    await this.em.persistAndFlush([folder, ...scraps, ...articles]);
+  }
+
+  /**
+   * Move scraps and/or articles to a folder
+   */
+  async moveItemsToFolder(
+    folderId: string | null,
+    userId: number,
+    scrapIds?: number[],
+    articleIds?: number[],
+  ): Promise<{ movedScraps: number; movedArticles: number }> {
+    let targetFolder: Folder | null = null;
+
+    // If folderId is provided, verify it exists and belongs to user
+    if (folderId) {
+      targetFolder = await this.folderRepository.findOne({
+        folderId,
+        user: { userId },
+        isDeleted: false,
+      });
+
+      if (!targetFolder) {
+        throw new NotFoundException('Target folder not found');
+      }
+    }
+
+    let movedScraps = 0;
+    let movedArticles = 0;
+
+    // Move scraps
+    if (scrapIds && scrapIds.length > 0) {
+      const scraps = await this.scrapRepository.find({
+        scrapId: { $in: scrapIds },
+        user: { userId },
+        isDeleted: false,
+      });
+
+      scraps.forEach((scrap) => {
+        scrap.folder = targetFolder || undefined;
+      });
+
+      movedScraps = scraps.length;
+      await this.em.persistAndFlush(scraps);
+    }
+
+    // Move articles
+    if (articleIds && articleIds.length > 0) {
+      const articles = await this.articleRepository.find({
+        articleId: { $in: articleIds },
+        user: { userId },
+        isDeleted: false,
+      });
+
+      articles.forEach((article) => {
+        article.folder = targetFolder || undefined;
+      });
+
+      movedArticles = articles.length;
+      await this.em.persistAndFlush(articles);
+    }
+
+    return { movedScraps, movedArticles };
+  }
+
+  /**
+   * Get folder contents (scraps, articles, and child folders)
+   */
+  async getFolderContents(
+    folderId: string,
+    userId: number,
+  ): Promise<FolderContentsDto> {
+    const folder = await this.folderRepository.findOne(
+      {
+        folderId,
+        user: { userId },
+        isDeleted: false,
+      },
+      {
+        populate: ['scraps', 'articles', 'childFolders'],
+      },
+    );
+
+    if (!folder) {
+      throw new NotFoundException('Folder not found');
+    }
+
+    // Get scraps with tags populated
+    const scraps = await this.scrapRepository.find(
+      {
+        folder: { folderId },
+        isDeleted: false,
+      },
+      {
+        populate: ['tags'],
+        orderBy: { createdAt: 'DESC' },
+      },
+    );
+
+    // Get articles with archives populated
+    const articles = await this.articleRepository.find(
+      {
+        folder: { folderId },
+        isDeleted: false,
+      },
+      {
+        populate: ['archives'],
+        orderBy: { createdAt: 'DESC' },
+      },
+    );
+
+    // Get child folders
+    const childFolders = await this.folderRepository.find(
+      {
+        parentFolder: { folderId },
+        isDeleted: false,
+      },
+      {
+        populate: ['childFolders', 'scraps', 'articles'],
+        orderBy: { name: 'ASC' },
+      },
+    );
+
+    return {
+      folder: await this.toFolderResponseDto(folder),
+      scraps: scraps.map((scrap) => ({
+        scrapId: scrap.scrapId,
+        url: scrap.url,
+        title: scrap.title,
+        contentPreview:
+          scrap.content && scrap.content.length > 100
+            ? scrap.content.substring(0, 100) + '...'
+            : scrap.content,
+        description: scrap.description,
+        heroImageUrl: scrap.heroImageUrl,
+        type: scrap.type,
+        createdAt: scrap.createdAt,
+        updatedAt: scrap.updatedAt,
+        tags: scrap.tags.getItems().map((tag) => ({
+          tagId: tag.tagId,
+          name: tag.name,
+        })),
+      })),
+      articles: articles.map((article) => ({
+        articleId: article.articleId,
+        topic: article.topic,
+        keyInsight: article.keyInsight,
+        title: article.getLatestTitle(),
+        generationStatus: article.generationStatus,
+        createdAt: article.createdAt,
+        updatedAt: article.updatedAt,
+      })),
+      childFolders: await Promise.all(
+        childFolders.map((f) => this.toFolderResponseDto(f)),
+      ),
+    };
+  }
+
+  /**
+   * Convert Folder entity to FolderResponseDto
+   */
+  private async toFolderResponseDto(
+    folder: Folder,
+  ): Promise<FolderResponseDto> {
+    // Ensure collections are initialized
+    await folder.scraps.loadItems();
+    await folder.articles.loadItems();
+    await folder.childFolders.loadItems();
+
+    return {
+      folderId: folder.folderId,
+      name: folder.name,
+      description: folder.description,
+      color: folder.color,
+      icon: folder.icon,
+      parentFolderId: folder.parentFolder?.folderId,
+      isDeleted: folder.isDeleted,
+      createdAt: folder.createdAt,
+      updatedAt: folder.updatedAt,
+      scrapCount: folder.scraps.getItems().filter((s) => !s.isDeleted).length,
+      articleCount: folder.articles.getItems().filter((a) => !a.isDeleted)
+        .length,
+      childFolderCount: folder.childFolders
+        .getItems()
+        .filter((f) => !f.isDeleted).length,
+    };
+  }
+}

--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -14,6 +14,7 @@ import { UserOAuth } from './users/entities/user-oauth.entity';
 import { WritingStyle } from './writing-styles/entities/writing-style.entity';
 import { WritingStyleExample } from './writing-styles/entities/writing-style-example.entity';
 import { Job } from './queue/entities/job-status.entity';
+import { Folder } from './folders/entities/folder.entity';
 
 export default defineConfig({
   host: process.env.DATABASE_HOST,
@@ -32,6 +33,7 @@ export default defineConfig({
     WritingStyle,
     WritingStyleExample,
     Job,
+    Folder,
   ],
   schema: 'public',
   debug: true,

--- a/src/scraps/entities/scrap.entity.ts
+++ b/src/scraps/entities/scrap.entity.ts
@@ -9,6 +9,7 @@ import {
 import { Tag } from '../../tags/entities/tag.entity';
 import { User } from '../../users/entities/user.entity';
 import { Article } from '../../articles/entities/article.entity';
+import { Folder } from '../../folders/entities/folder.entity';
 
 @Entity({ tableName: 'scraps' })
 export class Scrap {
@@ -129,6 +130,12 @@ export class Scrap {
 
   @ManyToOne(() => Article, { fieldName: 'article_id', nullable: true })
   article?: Article;
+
+  @ManyToOne(() => Folder, {
+    fieldName: 'folder_id',
+    nullable: true,
+  })
+  folder?: Folder;
 
   @OneToMany(() => Tag, (tag) => tag.scrap)
   tags: Collection<Tag> = new Collection<Tag>(this);

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -8,6 +8,7 @@ import {
 import { Scrap } from '../../scraps/entities/scrap.entity';
 import { Tag } from '../../tags/entities/tag.entity';
 import { UserOAuth } from './user-oauth.entity';
+import { Folder } from '../../folders/entities/folder.entity';
 
 export enum UserRole {
   USER = 'USER',
@@ -47,4 +48,7 @@ export class User {
 
   @OneToMany(() => UserOAuth, (oauth) => oauth.user)
   oauthAccounts: Collection<UserOAuth> = new Collection<UserOAuth>(this);
+
+  @OneToMany(() => Folder, (folder) => folder.user)
+  folders: Collection<Folder> = new Collection<Folder>(this);
 }


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-402](https://linear.app/chill-mato/issue/CHI-402/be-폴더-구조-및-통합-콘텐츠-뷰-api-구현)

## 📋 변경사항 요약

Chrome extension과 web client를 위한 **폴더 기능** 및 **통합 콘텐츠 뷰 API** 구현

### 1. 폴더 기능
- Folder 엔티티 추가 (계층 구조 지원)
- Article, Scrap에 폴더 관계 추가
- CRUD API 구현 (`/api/v1/folders`)
- 트랜잭션 처리 및 성능 최적화

### 2. 통합 콘텐츠 API
- 단일 엔드포인트로 Scraps + Articles 통합 조회 (`/api/v1/content/unified`)
- 폴더, 타입, 태그, 검색어 기반 필터링
- DB 레벨 페이지네이션 및 정렬
- GIN 인덱스를 통한 full-text search 최적화

### 3. 기타
- DTO 입력 검증 강화
- ArticleArchive 버전 복원 버그 수정


## 🗃️ 데이터베이스 변경사항

### 신규 테이블
- `folders`: 폴더 엔티티 (계층 구조 지원)

### 기존 테이블 수정
- `articles`, `scraps`: `folder_id` 컬럼 추가

### 인덱스 추가
- Scraps/Articles: user_id, folder_id, created_at, updated_at 복합 인덱스
- GIN 인덱스: title, content, topic, key_insight (full-text search)
- PostgreSQL `pg_trgm` 확장 필요

## 📦 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음