### PR TITLE
Iss/chi 404

### DIFF
--- a/src/api/content/dto/unified-content-query.dto.ts
+++ b/src/api/content/dto/unified-content-query.dto.ts
@@ -7,7 +7,7 @@ import {
   IsEnum,
   IsArray,
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Type, Transform } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export enum ContentType {
@@ -116,6 +116,13 @@ export class UnifiedContentQueryDto {
     example: ['javascript', 'tutorial'],
   })
   @IsOptional()
+  @Transform(({ value }) => {
+    // Handle both single string and array
+    if (typeof value === 'string') {
+      return [value];
+    }
+    return value;
+  })
   @IsArray()
   @IsString({ each: true })
   tags?: string[];

--- a/src/articles/entities/article.entity.ts
+++ b/src/articles/entities/article.entity.ts
@@ -11,6 +11,7 @@ import { ArticleArchive } from '../../article-archive/entities/article-archive.e
 import { User } from '../../users/entities/user.entity';
 import { Scrap } from '../../scraps/entities/scrap.entity';
 import { Folder } from '../../folders/entities/folder.entity';
+import { Tag } from '../../tags/entities/tag.entity';
 
 @Entity({ tableName: 'articles' })
 export class Article {
@@ -57,6 +58,9 @@ export class Article {
     nullable: true,
   })
   folder?: Folder;
+
+  @OneToMany(() => Tag, (tag) => tag.article)
+  tags = new Collection<Tag>(this);
 
   /**
    * CreateArticleDto로부터 Article 인스턴스를 생성합니다

--- a/src/content/content.service.ts
+++ b/src/content/content.service.ts
@@ -80,6 +80,7 @@ export class ContentService {
         sortBy,
         sortOrder,
         search,
+        tags,
         page,
         limit,
         includeScraps, // If both types, we need to merge and paginate later
@@ -236,12 +237,13 @@ export class ContentService {
       sortBy: SortByField;
       sortOrder: string;
       search?: string;
+      tags?: string[];
       page: number;
       limit: number;
       includeScraps?: boolean;
     },
   ): Promise<{ items: Article[]; total: number }> {
-    const { folderId, sortBy, sortOrder, search, page, limit, includeScraps } =
+    const { folderId, sortBy, sortOrder, search, tags, page, limit, includeScraps } =
       options;
 
     const where: any = {
@@ -268,6 +270,13 @@ export class ContentService {
       ];
     }
 
+    // Tag filter (OR logic - match any of the provided tags)
+    if (tags && tags.length > 0) {
+      where.tags = {
+        name: { $in: tags },
+      };
+    }
+
     // Get total count
     const total = await this.articleRepository.count(where);
 
@@ -290,9 +299,9 @@ export class ContentService {
     const orderBy = this.getSortField(sortBy, 'article');
     const order = sortOrder === 'ASC' ? QueryOrder.ASC : QueryOrder.DESC;
 
-    // Fetch articles with archives populated
+    // Fetch articles with archives and tags populated
     const items = await this.articleRepository.find(where, {
-      populate: ['archives'],
+      populate: ['archives', 'tags'],
       orderBy: { [orderBy]: order },
       offset,
       limit: fetchLimit,
@@ -426,6 +435,10 @@ export class ContentService {
       topic: article.topic,
       keyInsight: article.keyInsight,
       generationStatus: article.generationStatus,
+      tags: article.tags?.getItems().map((tag) => ({
+        tagId: tag.tagId,
+        name: tag.name,
+      })),
     };
   }
 

--- a/src/tags/entities/tag.entity.ts
+++ b/src/tags/entities/tag.entity.ts
@@ -7,6 +7,7 @@ import {
   Property,
 } from '@mikro-orm/core';
 import { Scrap } from '../../scraps/entities/scrap.entity';
+import { Article } from '../../articles/entities/article.entity';
 import { User } from '../../users/entities/user.entity';
 
 @Entity({ tableName: 'tags' })
@@ -14,8 +15,14 @@ export class Tag {
   @BeforeCreate()
   validate() {
     const hasScrap = this.scrap !== null && this.scrap !== undefined;
-    if (!hasScrap) {
-      throw new Error('Tag must be associated with a scrap');
+    const hasArticle = this.article !== null && this.article !== undefined;
+
+    if (!hasScrap && !hasArticle) {
+      throw new Error('Tag must be associated with either a scrap or an article');
+    }
+
+    if (hasScrap && hasArticle) {
+      throw new Error('Tag cannot be associated with both a scrap and an article');
     }
   }
 
@@ -31,6 +38,9 @@ export class Tag {
   @ManyToOne(() => User, { fieldName: 'user_id' })
   user: User;
 
-  @ManyToOne(() => Scrap, { fieldName: 'scrap_id', nullable: false })
+  @ManyToOne(() => Scrap, { fieldName: 'scrap_id', nullable: true })
   scrap?: Scrap;
+
+  @ManyToOne(() => Article, { fieldName: 'article_id', nullable: true })
+  article?: Article;
 }


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-404](https://linear.app/chill-mato/issue/CHI-404/be-article-엔티티-태그-기능-추가)

## 변경사항 요약

Article 엔티티에 태그 기능 추가 및 통합 콘텐츠 API에서 Article 태그 필터링 지원

### 주요 변경사항
- Tag 엔티티: Article 관계 추가, scrap_id nullable 변경
- Article 엔티티: tags OneToMany 관계 추가
- ContentService: Article 태그 필터링 로직 구현
- API: `GET /api/v1/content/unified?tags=<name>` 호출 시 Article도 필터링

## 데이터베이스 변경사항

### 기존 테이블 수정
- `tags`: `article_id` 컬럼 추가 (nullable, FK)
- `tags`: `scrap_id` nullable 변경
- CHECK 제약조건: scrap_id와 article_id 중 하나만 필수

### 인덱스 추가
- `idx_tags_article_id`, `idx_tags_article_name`, `idx_tags_name`

**배포 전 필수**: 데이터베이스 마이그레이션 실행

## 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음