### PR TITLE
[CHI-422] Slack Bot API 구현 및 사용자 매핑

### DIFF
--- a/src/agents/agents.module.ts
+++ b/src/agents/agents.module.ts
@@ -21,6 +21,10 @@ import { ArticleRegeneratorService } from '../ai-workflows/services/article-rege
     FileAnalysisAgentService,
     NewsletterAgentService,
   ],
-  exports: [FileAnalysisAgentService, NewsletterAgentService],
+  exports: [
+    VertexAiFactory, // Export for use in other modules
+    FileAnalysisAgentService,
+    NewsletterAgentService,
+  ],
 })
 export class AgentsModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { QueueModule } from './queue/queue.module';
 import { AdminModule } from './api/admin/admin.module';
 import { FoldersModule } from './folders/folders.module';
 import { ContentModule } from './content/content.module';
+import { SlackBotModule } from './slack-bot/slack-bot.module';
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { ContentModule } from './content/content.module';
     ContentModule, // 통합 콘텐츠 모듈 추가
     QueueModule, // SQS 큐 모듈 추가
     AdminModule, // 관리자 모듈 추가
+    SlackBotModule, // Slack Bot API 모듈 추가
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/slack-bot/dto/generate-report.dto.ts
+++ b/src/slack-bot/dto/generate-report.dto.ts
@@ -1,0 +1,106 @@
+import {
+  IsString,
+  IsArray,
+  IsNumber,
+  IsOptional,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Slack 메시지 DTO
+ */
+export class SlackMessageDto {
+  @ApiProperty({
+    description: 'Slack 메시지 텍스트',
+    example: '프로젝트 A 진행 상황 공유',
+  })
+  @IsString()
+  text: string;
+
+  @ApiProperty({
+    description: 'Slack 타임스탬프',
+    example: '1730426400.123456',
+  })
+  @IsString()
+  timestamp: string;
+
+  @ApiProperty({
+    description: '채널 ID',
+    example: 'C08N8PYJW73',
+  })
+  @IsString()
+  channel: string;
+
+  @ApiProperty({
+    description: '채널 이름',
+    example: 'general',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  channelName?: string;
+}
+
+/**
+ * 날짜 범위 DTO
+ */
+export class DateRangeDto {
+  @ApiProperty({
+    description: '시작 날짜',
+    example: '11월 1일',
+  })
+  @IsString()
+  from: string;
+
+  @ApiProperty({
+    description: '종료 날짜',
+    example: '11월 5일',
+  })
+  @IsString()
+  to: string;
+}
+
+/**
+ * 보고서 생성 요청 DTO
+ */
+export class GenerateReportDto {
+  @ApiProperty({
+    description: '보고서 주제',
+    example: '주간 업무 보고서 (11월 1일 ~ 11월 5일)',
+  })
+  @IsString()
+  topic: string;
+
+  @ApiProperty({
+    description: '핵심 인사이트',
+    example: '이번 주 주요 업무 성과와 진행 상황을 요약합니다.',
+  })
+  @IsString()
+  keyInsight: string;
+
+  @ApiProperty({
+    description: 'Slack 메시지 목록',
+    type: [SlackMessageDto],
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SlackMessageDto)
+  messages: SlackMessageDto[];
+
+  @ApiProperty({
+    description: '날짜 범위',
+    type: DateRangeDto,
+  })
+  @ValidateNested()
+  @Type(() => DateRangeDto)
+  dateRange: DateRangeDto;
+
+  @ApiProperty({
+    description: '메시지 개수',
+    example: 15,
+  })
+  @IsNumber()
+  messageCount: number;
+}

--- a/src/slack-bot/dto/generate-report.dto.ts
+++ b/src/slack-bot/dto/generate-report.dto.ts
@@ -103,4 +103,27 @@ export class GenerateReportDto {
   })
   @IsNumber()
   messageCount: number;
+
+  @ApiProperty({
+    description: 'Slack User ID',
+    example: 'U08N8PYDQ3B',
+  })
+  @IsString()
+  slackUserId: string;
+
+  @ApiProperty({
+    description: 'Slack Team/Workspace ID',
+    example: 'T08N8PYCC3T',
+  })
+  @IsString()
+  slackTeamId: string;
+
+  @ApiProperty({
+    description: 'Slack 사용자 이름 (선택사항)',
+    example: 'qusseun',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  slackUserName?: string;
 }

--- a/src/slack-bot/dto/report-response.dto.ts
+++ b/src/slack-bot/dto/report-response.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * 보고서 생성 응답 DTO
+ */
+export class ReportResponseDto {
+  @ApiProperty({
+    description: '생성된 아티클 ID',
+    example: 123,
+  })
+  articleId: number;
+
+  @ApiProperty({
+    description: '보고서 내용 (Markdown)',
+    example: '# 주간 업무 보고서\n\n## 주요 성과\n...',
+  })
+  content: string;
+
+  @ApiProperty({
+    description: '보고서 주제',
+    example: '주간 업무 보고서 (11월 1일 ~ 11월 5일)',
+  })
+  topic: string;
+
+  @ApiProperty({
+    description: '생성 상태',
+    enum: ['completed', 'failed'],
+    example: 'completed',
+  })
+  generationStatus: 'completed' | 'failed';
+
+  @ApiProperty({
+    description: '생성 일시',
+    example: '2025-11-05T05:00:00Z',
+  })
+  createdAt: Date;
+}

--- a/src/slack-bot/guards/api-key-auth.guard.ts
+++ b/src/slack-bot/guards/api-key-auth.guard.ts
@@ -1,0 +1,54 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+  Logger,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * API Key 인증 Guard
+ *
+ * X-API-Key 헤더를 검증하여 Slack Bot API에 대한 접근을 제어합니다.
+ */
+@Injectable()
+export class ApiKeyAuthGuard implements CanActivate {
+  private readonly logger = new Logger(ApiKeyAuthGuard.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const apiKey = request.headers['x-api-key'];
+
+    const validApiKey = this.configService.get<string>('SLACK_BOT_API_KEY');
+
+    if (!validApiKey) {
+      this.logger.error('SLACK_BOT_API_KEY is not configured');
+      throw new UnauthorizedException('API Key authentication is not configured');
+    }
+
+    if (!apiKey) {
+      this.logger.warn('Missing X-API-Key header', {
+        ip: request.ip,
+        path: request.path,
+      });
+      throw new UnauthorizedException('Missing X-API-Key header');
+    }
+
+    if (apiKey !== validApiKey) {
+      this.logger.warn('Invalid API Key', {
+        ip: request.ip,
+        path: request.path,
+      });
+      throw new UnauthorizedException('Invalid API Key');
+    }
+
+    this.logger.debug('API Key validated successfully', {
+      path: request.path,
+    });
+
+    return true;
+  }
+}

--- a/src/slack-bot/slack-bot.controller.ts
+++ b/src/slack-bot/slack-bot.controller.ts
@@ -1,0 +1,174 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Param,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  Version,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiHeader,
+} from '@nestjs/swagger';
+import { SlackBotService } from './slack-bot.service';
+import { GenerateReportDto } from './dto/generate-report.dto';
+import { ReportResponseDto } from './dto/report-response.dto';
+import { ApiKeyAuthGuard } from './guards/api-key-auth.guard';
+
+/**
+ * Slack Bot API 컨트롤러
+ *
+ * Slack Bot 전용 API 엔드포인트를 제공합니다.
+ * API Key 인증을 사용하여 간단하게 보고서를 생성할 수 있습니다.
+ */
+@ApiTags('Slack Bot')
+@Controller('slack-bot')
+@UseGuards(ApiKeyAuthGuard)
+export class SlackBotController {
+  private readonly logger = new Logger(SlackBotController.name);
+
+  constructor(private readonly slackBotService: SlackBotService) {}
+
+  /**
+   * Slack 메시지로 주간 보고서 생성
+   */
+  @Version('1')
+  @Post('generate-report')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Slack 메시지로 주간 보고서 생성',
+    description:
+      'Slack Bot 전용 API입니다. API Key 인증이 필요하며, Slack 메시지를 받아 AI 기반 주간 보고서를 생성합니다. 완성된 보고서를 즉시 반환합니다.',
+  })
+  @ApiHeader({
+    name: 'X-API-Key',
+    description: 'Slack Bot API Key (SLACK_BOT_API_KEY 환경 변수)',
+    required: true,
+    schema: {
+      type: 'string',
+      example: 'tyquill-slack-bot-secret-key-2025',
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: '보고서 생성 완료',
+    type: ReportResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Invalid or missing API Key',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 401 },
+        message: { type: 'string', example: 'Invalid API Key' },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Report generation failed',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 500 },
+        message: { type: 'string', example: 'Failed to generate report' },
+        error: { type: 'string', example: 'Internal Server Error' },
+      },
+    },
+  })
+  async generateReport(
+    @Body() dto: GenerateReportDto,
+  ): Promise<ReportResponseDto> {
+    this.logger.log('Received report generation request', {
+      topic: dto.topic,
+      messageCount: dto.messageCount,
+      dateRange: dto.dateRange,
+    });
+
+    return await this.slackBotService.generateReport(dto);
+  }
+
+  /**
+   * 보고서 조회 (공유 기능에서 사용)
+   */
+  @Version('1')
+  @Get('reports/:articleId')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '생성된 보고서 조회',
+    description:
+      'articleId로 이미 생성된 보고서를 조회합니다. Slack Bot의 공유 기능에서 사용됩니다.',
+  })
+  @ApiHeader({
+    name: 'X-API-Key',
+    description: 'Slack Bot API Key',
+    required: true,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '보고서 조회 성공',
+    type: ReportResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Report not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'Report not found' },
+      },
+    },
+  })
+  async getReport(
+    @Param('articleId') articleId: string,
+  ): Promise<ReportResponseDto> {
+    this.logger.log('Received report retrieval request', {
+      articleId: parseInt(articleId, 10),
+    });
+
+    const report = await this.slackBotService.getReport(
+      parseInt(articleId, 10),
+    );
+
+    if (!report) {
+      throw new NotFoundException(`Report not found: ${articleId}`);
+    }
+
+    return report;
+  }
+
+  /**
+   * Slack Bot API 상태 확인
+   */
+  @Version('1')
+  @Get('health')
+  @ApiOperation({
+    summary: 'Slack Bot API 상태 확인',
+    description: 'API가 정상 작동하는지 확인합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'API is healthy',
+    schema: {
+      type: 'object',
+      properties: {
+        status: { type: 'string', example: 'ok' },
+        timestamp: { type: 'string', example: '2025-11-05T05:00:00.000Z' },
+        service: { type: 'string', example: 'slack-bot-api' },
+      },
+    },
+  })
+  healthCheck() {
+    this.logger.debug('Health check requested');
+    return this.slackBotService.healthCheck();
+  }
+}

--- a/src/slack-bot/slack-bot.module.ts
+++ b/src/slack-bot/slack-bot.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { SlackBotController } from './slack-bot.controller';
+import { SlackBotService } from './slack-bot.service';
+import { SlackReportGeneratorService } from './slack-report-generator.service';
+import { AgentsModule } from '../agents/agents.module';
+import { Article } from '../articles/entities/article.entity';
+import { ArticleArchive } from '../article-archive/entities/article-archive.entity';
+import { User } from '../users/entities/user.entity';
+
+/**
+ * Slack Bot 모듈
+ *
+ * Slack Bot 전용 API를 제공합니다.
+ * API Key 인증을 사용하여 빠른 보고서 생성 (단일 LLM 호출)
+ */
+@Module({
+  imports: [
+    MikroOrmModule.forFeature([Article, ArticleArchive, User]),
+    AgentsModule, // VertexAiFactory 사용
+  ],
+  controllers: [SlackBotController],
+  providers: [SlackBotService, SlackReportGeneratorService],
+  exports: [SlackBotService],
+})
+export class SlackBotModule {}

--- a/src/slack-bot/slack-bot.module.ts
+++ b/src/slack-bot/slack-bot.module.ts
@@ -7,6 +7,7 @@ import { AgentsModule } from '../agents/agents.module';
 import { Article } from '../articles/entities/article.entity';
 import { ArticleArchive } from '../article-archive/entities/article-archive.entity';
 import { User } from '../users/entities/user.entity';
+import { UserOAuth } from '../users/entities/user-oauth.entity';
 
 /**
  * Slack Bot 모듈
@@ -16,7 +17,7 @@ import { User } from '../users/entities/user.entity';
  */
 @Module({
   imports: [
-    MikroOrmModule.forFeature([Article, ArticleArchive, User]),
+    MikroOrmModule.forFeature([Article, ArticleArchive, User, UserOAuth]),
     AgentsModule, // VertexAiFactory 사용
   ],
   controllers: [SlackBotController],

--- a/src/slack-bot/slack-bot.service.ts
+++ b/src/slack-bot/slack-bot.service.ts
@@ -5,6 +5,7 @@ import { EntityManager, EntityRepository } from '@mikro-orm/core';
 import { Article } from '../articles/entities/article.entity';
 import { ArticleArchive } from '../article-archive/entities/article-archive.entity';
 import { User } from '../users/entities/user.entity';
+import { UserOAuth, OAuthProvider } from '../users/entities/user-oauth.entity';
 import {
   GenerateReportDto,
   SlackMessageDto,
@@ -29,6 +30,8 @@ export class SlackBotService {
     private readonly articleRepository: EntityRepository<Article>,
     @InjectRepository(User)
     private readonly userRepository: EntityRepository<User>,
+    @InjectRepository(UserOAuth)
+    private readonly userOAuthRepository: EntityRepository<UserOAuth>,
     private readonly configService: ConfigService,
     private readonly reportGenerator: SlackReportGeneratorService,
   ) {}
@@ -48,15 +51,12 @@ export class SlackBotService {
     const startTime = Date.now();
 
     try {
-      // 1. 서비스 계정 가져오기
-      const serviceAccountId = this.getServiceAccountId();
-      const user = await this.userRepository.findOne({ userId: serviceAccountId });
-
-      if (!user) {
-        throw new NotFoundException(
-          `Service account not found: ${serviceAccountId}`
-        );
-      }
+      // 1. Slack 사용자로 Tyquill User 매핑 (자동 생성)
+      const user = await this.findOrCreateUserBySlackId(
+        dto.slackUserId,
+        dto.slackTeamId,
+        dto.slackUserName,
+      );
 
       // 2. Slack 메시지를 프롬프트 형식으로 변환
       const formattedMessages = this.formatMessagesForPrompt(
@@ -188,6 +188,77 @@ export class SlackBotService {
     }
 
     return parseInt(serviceAccountId, 10);
+  }
+
+  /**
+   * Slack User ID로 사용자 찾기 또는 생성
+   *
+   * UserOAuth 테이블을 사용하여 Slack 사용자를 Tyquill User와 매핑합니다.
+   * 기존 매핑이 없으면 새로운 User와 UserOAuth 레코드를 자동 생성합니다.
+   */
+  async findOrCreateUserBySlackId(
+    slackUserId: string,
+    slackTeamId: string,
+    slackUserName?: string,
+  ): Promise<User> {
+    this.logger.debug('Finding or creating user by Slack ID', {
+      slackUserId,
+      slackTeamId,
+      slackUserName,
+    });
+
+    // 1. Slack OAuth 레코드 찾기
+    let userOAuth = await this.userOAuthRepository.findOne(
+      {
+        oauthProvider: OAuthProvider.SLACK,
+        oauthId: slackUserId,
+      },
+      { populate: ['user'] },
+    );
+
+    // 2. 기존 OAuth 레코드가 있으면 User 반환
+    if (userOAuth) {
+      this.logger.debug('Found existing Slack user', {
+        userId: userOAuth.user.userId,
+        slackUserId,
+      });
+      return userOAuth.user;
+    }
+
+    // 3. 새로운 User와 UserOAuth 생성
+    this.logger.log('Creating new user for Slack ID', {
+      slackUserId,
+      slackTeamId,
+      slackUserName,
+    });
+
+    // 3-1. User 생성
+    const user = new User();
+    user.email = `slack_${slackUserId}@tyquill-slack-bot.local`; // 임시 이메일
+    user.name = slackUserName || `Slack User ${slackUserId.substring(0, 8)}`;
+
+    await this.em.persistAndFlush(user);
+
+    // 3-2. UserOAuth 생성
+    userOAuth = new UserOAuth({
+      oauthProvider: OAuthProvider.SLACK,
+      oauthId: slackUserId,
+      user,
+      profileData: {
+        slack_user_id: slackUserId,
+        slack_team_id: slackTeamId,
+        slack_user_name: slackUserName,
+      },
+    });
+
+    await this.em.persistAndFlush(userOAuth);
+
+    this.logger.log('Created new user and OAuth mapping', {
+      userId: user.userId,
+      slackUserId,
+    });
+
+    return user;
   }
 
   /**

--- a/src/slack-bot/slack-bot.service.ts
+++ b/src/slack-bot/slack-bot.service.ts
@@ -1,0 +1,234 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { EntityManager, EntityRepository } from '@mikro-orm/core';
+import { Article } from '../articles/entities/article.entity';
+import { ArticleArchive } from '../article-archive/entities/article-archive.entity';
+import { User } from '../users/entities/user.entity';
+import {
+  GenerateReportDto,
+  SlackMessageDto,
+  DateRangeDto,
+} from './dto/generate-report.dto';
+import { ReportResponseDto } from './dto/report-response.dto';
+import { SlackReportGeneratorService } from './slack-report-generator.service';
+
+/**
+ * Slack Bot 서비스
+ *
+ * Slack 메시지를 받아서 AI 기반 주간 보고서를 생성합니다.
+ * 단일 LLM 호출로 빠른 생성 (5-10초)
+ */
+@Injectable()
+export class SlackBotService {
+  private readonly logger = new Logger(SlackBotService.name);
+
+  constructor(
+    private readonly em: EntityManager,
+    @InjectRepository(Article)
+    private readonly articleRepository: EntityRepository<Article>,
+    @InjectRepository(User)
+    private readonly userRepository: EntityRepository<User>,
+    private readonly configService: ConfigService,
+    private readonly reportGenerator: SlackReportGeneratorService,
+  ) {}
+
+  /**
+   * Slack 메시지로 주간 보고서 생성
+   *
+   * 빠른 단일 LLM 호출로 5-10초 내 완료
+   */
+  async generateReport(dto: GenerateReportDto): Promise<ReportResponseDto> {
+    this.logger.log('Generating report from Slack messages (fast mode)', {
+      messageCount: dto.messageCount,
+      topic: dto.topic,
+      dateRange: dto.dateRange,
+    });
+
+    const startTime = Date.now();
+
+    try {
+      // 1. 서비스 계정 가져오기
+      const serviceAccountId = this.getServiceAccountId();
+      const user = await this.userRepository.findOne({ userId: serviceAccountId });
+
+      if (!user) {
+        throw new NotFoundException(
+          `Service account not found: ${serviceAccountId}`
+        );
+      }
+
+      // 2. Slack 메시지를 프롬프트 형식으로 변환
+      const formattedMessages = this.formatMessagesForPrompt(
+        dto.messages,
+        dto.dateRange,
+      );
+
+      this.logger.debug('Formatted messages for AI', {
+        messageLength: formattedMessages.length,
+      });
+
+      // 3. AI로 빠른 보고서 생성 (단일 LLM 호출)
+      const { title, content } = await this.reportGenerator.generateReport({
+        topic: dto.topic,
+        keyInsight: dto.keyInsight,
+        messages: formattedMessages,
+      });
+
+      const aiGenerationTime = Date.now() - startTime;
+
+      this.logger.log('AI report generated', {
+        title,
+        contentLength: content.length,
+        aiTime: `${aiGenerationTime}ms`,
+      });
+
+      // 4. Article 엔티티 생성 및 저장
+      const article = new Article();
+      article.topic = dto.topic;
+      article.keyInsight = dto.keyInsight;
+      article.generationParams = formattedMessages;
+      article.generationStatus = 'completed';
+      article.user = user;
+
+      await this.em.persistAndFlush(article);
+
+      // 5. ArticleArchive에 콘텐츠 저장
+      const archive = new ArticleArchive();
+      archive.title = title;
+      archive.content = content;
+      archive.versionNumber = 1;
+      archive.article = article;
+
+      await this.em.persistAndFlush(archive);
+
+      const totalTime = Date.now() - startTime;
+
+      this.logger.log('Report saved to database', {
+        articleId: article.articleId,
+        totalTime: `${totalTime}ms`,
+      });
+
+      // 6. 응답 반환
+      return {
+        articleId: article.articleId,
+        content,
+        topic: dto.topic,
+        generationStatus: 'completed',
+        createdAt: article.createdAt,
+      };
+    } catch (error) {
+      this.logger.error('Failed to generate report', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 보고서 조회 (articleId로)
+   */
+  async getReport(articleId: number): Promise<ReportResponseDto | null> {
+    this.logger.log('Fetching report from database', { articleId });
+
+    try {
+      // Article과 최신 ArticleArchive 조회
+      const article = await this.em.findOne(
+        Article,
+        { articleId },
+        {
+          populate: ['archives'],
+          orderBy: { archives: { versionNumber: 'DESC' } },
+        },
+      );
+
+      if (!article) {
+        this.logger.warn('Report not found', { articleId });
+        return null;
+      }
+
+      // 최신 버전의 archive 가져오기
+      const latestArchive = article.archives?.getItems()[0];
+
+      if (!latestArchive) {
+        this.logger.warn('Report has no archive content', { articleId });
+        return null;
+      }
+
+      this.logger.log('Report fetched successfully', {
+        articleId,
+        versionNumber: latestArchive.versionNumber,
+      });
+
+      // For getReport, we only return if status is 'completed'
+      // If it's 'processing' or 'failed', we return null or completed with warning
+      const status = article.generationStatus === 'completed' ? 'completed' : 'failed';
+
+      return {
+        articleId: article.articleId,
+        content: latestArchive.content,
+        topic: latestArchive.title || 'Untitled Report',
+        generationStatus: status,
+        createdAt: article.createdAt,
+      };
+    } catch (error) {
+      this.logger.error('Failed to fetch report', { articleId, error });
+      throw error;
+    }
+  }
+
+  /**
+   * 서비스 계정 ID 가져오기
+   */
+  private getServiceAccountId(): number {
+    const serviceAccountId = this.configService.get<string>(
+      'SLACK_BOT_SERVICE_ACCOUNT_ID',
+    );
+
+    if (!serviceAccountId) {
+      throw new Error('SLACK_BOT_SERVICE_ACCOUNT_ID is not configured');
+    }
+
+    return parseInt(serviceAccountId, 10);
+  }
+
+  /**
+   * Slack 메시지를 AI 프롬프트용 문자열로 변환
+   */
+  private formatMessagesForPrompt(
+    messages: SlackMessageDto[],
+    dateRange: DateRangeDto,
+  ): string {
+    const formattedMessages = messages
+      .map((msg, index) => {
+        const date = new Date(parseFloat(msg.timestamp) * 1000);
+        const dateStr = date.toLocaleDateString('ko-KR', {
+          month: 'short',
+          day: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+        });
+        const channel = msg.channelName ? `#${msg.channelName}` : msg.channel;
+        return `[${index + 1}] ${dateStr} (${channel}): ${msg.text}`;
+      })
+      .join('\n\n');
+
+    return `
+기간: ${dateRange.from} ~ ${dateRange.to}
+총 메시지: ${messages.length}개
+
+=== Slack 메시지 목록 ===
+
+${formattedMessages}
+    `.trim();
+  }
+
+  /**
+   * 헬스 체크
+   */
+  async healthCheck() {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      service: 'slack-bot-api',
+    };
+  }
+}

--- a/src/slack-bot/slack-report-generator.service.ts
+++ b/src/slack-bot/slack-report-generator.service.ts
@@ -1,0 +1,234 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ChatVertexAI } from '../ai-workflows/services/vertex-chat.model';
+import { VertexAiFactory } from '../ai-workflows/services/vertex-ai.factory';
+
+/**
+ * 빠른 Slack 보고서 생성 서비스
+ *
+ * 복잡한 워크플로우 대신 단일 LLM 호출로 5-10초 내에 보고서 생성
+ */
+@Injectable()
+export class SlackReportGeneratorService {
+  private readonly logger = new Logger(SlackReportGeneratorService.name);
+  private readonly llm: ChatVertexAI;
+
+  constructor(private readonly vertexFactory: VertexAiFactory) {
+    // Gemini 2.5 Flash Lite - 빠른 응답 모델
+    this.llm = this.vertexFactory.buildChat({
+      model: 'gemini-2.5-flash-lite',
+      temperature: 0.7,
+      thinkingBudget: 0,
+      maxOutputTokens: 8192,
+    });
+
+    this.logger.log('SlackReportGeneratorService initialized with gemini-2.5-flash-lite');
+  }
+
+  /**
+   * Slack 메시지로부터 주간 보고서 생성
+   *
+   * @param input 보고서 생성에 필요한 입력 데이터
+   * @returns 생성된 제목과 마크다운 콘텐츠
+   */
+  async generateReport(input: {
+    topic: string;
+    keyInsight: string;
+    messages: string;
+  }): Promise<{ title: string; content: string }> {
+    this.logger.log('Generating report with single LLM call', {
+      topic: input.topic,
+      messageLength: input.messages.length,
+    });
+
+    const startTime = Date.now();
+
+    try {
+      const prompt = this.buildPrompt(input);
+
+      this.logger.debug('Invoking Gemini 2.5 Flash Lite', {
+        promptLength: prompt.length,
+      });
+
+      // 단일 LLM 호출
+      const response = await this.llm.invoke(prompt);
+
+      const elapsedTime = Date.now() - startTime;
+
+      this.logger.log('LLM response received', {
+        elapsedTime: `${elapsedTime}ms`,
+        contentLength: typeof response.content === 'string' ? response.content.length : 0,
+      });
+
+      // 응답 파싱
+      const result = this.parseResponse(response.content);
+
+      this.logger.log('Report generated successfully', {
+        title: result.title,
+        contentLength: result.content.length,
+        totalTime: `${Date.now() - startTime}ms`,
+      });
+
+      return result;
+    } catch (error) {
+      this.logger.error('Failed to generate report', error);
+      throw error;
+    }
+  }
+
+  /**
+   * LLM 프롬프트 생성
+   */
+  private buildPrompt(input: {
+    topic: string;
+    keyInsight: string;
+    messages: string;
+  }): string {
+    return `당신은 Slack 메시지를 분석하여 전문적인 주간 업무 보고서를 작성하는 비서입니다.
+
+<역할>
+팀원들의 Slack 메시지를 분석하여 핵심 업무 내용을 파악하고,
+경영진에게 보고할 수 있는 체계적이고 전문적인 주간 보고서를 작성합니다.
+</역할>
+
+<작성 규칙>
+1. 캐주얼한 Slack 대화를 전문적인 업무 보고서 톤으로 변환하세요
+2. 중복된 내용은 제거하고 핵심만 추출하세요
+3. 정량적 성과와 구체적인 진행 상황을 강조하세요
+4. 날짜별 또는 프로젝트별로 논리적으로 구조화하세요
+5. Slack mrkdwn 형식으로 작성하세요 (표준 마크다운과 다름!)
+6. 다음 주 계획이나 액션 아이템이 있다면 포함하세요
+</작성 규칙>
+
+<Slack mrkdwn 포맷 규칙>
+CRITICAL: Slack은 표준 마크다운과 다른 형식을 사용합니다!
+
+✅ 올바른 Slack mrkdwn:
+- 볼드체: *텍스트* (별표 1개)
+- 이탤릭: _텍스트_ (언더스코어)
+- 취소선: ~텍스트~
+- 코드: \`code\`
+- 링크: <https://example.com|링크 텍스트> 또는 <https://example.com>
+- 리스트: • 또는 - 로 시작
+- 이모지: :chart_with_upwards_trend: (영어 코드만 가능)
+
+❌ 사용 금지:
+- ## 제목 (헤더 문법 없음 - 대신 *볼드체*로 제목 표현)
+- **텍스트** (별표 2개는 렌더링 안됨)
+- [텍스트](url) (마크다운 링크 문법 안됨)
+- :막대_차트: (한글 이모지 코드 안됨)
+
+이모지 매핑 (반드시 영어 코드 사용):
+- 📊 차트 → :bar_chart:
+- 📈 상승 → :chart_with_upwards_trend:
+- 🔍 검색 → :mag:
+- 🎯 목표 → :dart:
+- ✅ 체크 → :white_check_mark:
+- 💡 아이디어 → :bulb:
+- 🚀 로켓 → :rocket:
+- ⚡ 번개 → :zap:
+- 🏆 트로피 → :trophy:
+- 📅 날짜 → :calendar:
+- ✨ 반짝임 → :sparkles:
+- 💬 말풍선 → :speech_balloon:
+- 📄 문서 → :page_facing_up:
+- 📝 메모 → :memo:
+- ⭐ 별 → :star:
+
+경고: :막대_차트:, :반짝임:, :말풍선: 같은 한글 이모지 코드는 절대 사용하지 마세요!
+반드시 :bar_chart:, :sparkles:, :speech_balloon: 같은 영어 코드만 사용하세요!
+</Slack mrkdwn 포맷 규칙>
+
+<출력 형식>
+반드시 다음 Slack mrkdwn 형식으로 출력하세요:
+
+TITLE: [간결하고 명확한 보고서 제목 - 20자 이내]
+
+CONTENT:
+*:bar_chart: 요약*
+[핵심 성과와 주요 업무를 3-5줄로 요약. *중요한 키워드*는 볼드 처리.]
+
+*:mag: 주요 활동*
+
+*프로젝트 A 진행*
+• *날짜*: 주요 업무 내용을 구체적으로 작성
+• 정량적 성과가 있다면 숫자와 함께 명시
+• 링크가 있다면 <https://example.com|링크 텍스트> 형식 사용
+
+*프로젝트 B 개발*
+• 업무 내용 1
+• 업무 내용 2
+
+*:chart_with_upwards_trend: 성과 및 지표*
+[정량적 성과를 숫자와 함께 명시]
+
+*:dart: 다음 주 계획*
+• 액션 아이템 1
+• 액션 아이템 2
+
+주의사항:
+- 헤더는 *볼드체*로만 표현 (##이나 ### 사용 금지)
+- 영어 이모지 코드만 사용 (:bar_chart:, :sparkles: 등)
+- 링크는 <url|text> 형식
+- 리스트는 • 로 시작
+</출력 형식>
+
+<입력 데이터>
+기간: ${input.topic}
+핵심 인사이트: ${input.keyInsight}
+
+Slack 메시지:
+${input.messages}
+</입력 데이터>
+
+위 Slack 메시지들을 분석하여 전문적인 주간 업무 보고서를 작성해주세요.
+캐주얼한 표현은 모두 비즈니스 톤으로 변환하고, 중요한 업무 내용만 추출하세요.
+반드시 Slack mrkdwn 형식 규칙을 정확히 따라주세요!
+`;
+  }
+
+  /**
+   * LLM 응답 파싱
+   *
+   * TITLE: ... 과 CONTENT: ... 형식에서 추출
+   */
+  private parseResponse(llmResponse: unknown): { title: string; content: string } {
+    // llmResponse를 문자열로 변환
+    let text: string;
+
+    if (typeof llmResponse === 'string') {
+      text = llmResponse;
+    } else if (llmResponse && typeof llmResponse === 'object' && 'content' in llmResponse) {
+      const contentValue = (llmResponse as { content: unknown }).content;
+      text = String(contentValue || '');
+    } else {
+      text = String(llmResponse || '');
+    }
+
+    this.logger.debug('Parsing LLM response', {
+      textLength: text.length,
+      preview: text.substring(0, 200),
+    });
+
+    // TITLE: 추출
+    const titleMatch = text.match(/TITLE:\s*(.+?)(?:\n|$)/i);
+    const title = titleMatch
+      ? titleMatch[1].trim()
+      : '주간 업무 보고서';
+
+    // CONTENT: 이후 부분 추출
+    const contentMatch = text.match(/CONTENT:\s*([\s\S]+)/i);
+    const contentPart = contentMatch
+      ? contentMatch[1].trim()
+      : text;
+
+    // 만약 구조화된 응답이 아니라면 전체를 content로 사용
+    const finalContent = contentPart.length > 100 ? contentPart : text;
+
+    this.logger.debug('Parsed response', {
+      title,
+      contentLength: finalContent.length,
+    });
+
+    return { title, content: finalContent };
+  }
+}

--- a/src/users/entities/user-oauth.entity.ts
+++ b/src/users/entities/user-oauth.entity.ts
@@ -22,6 +22,7 @@ export enum OAuthProvider {
   GITHUB = 'github',
   FACEBOOK = 'facebook',
   APPLE = 'apple',
+  SLACK = 'slack',
 }
 
 @Entity({ tableName: 'user_oauth' })


### PR DESCRIPTION
## 🔗 연관 이슈
 Closes: [CHI-422](https://linear.app/chill-mato/issue/CHI-422/)

 ## 변경사항 요약
 Slack 메시지를 받아 AI 기반 주간 보고서를 생성하는 Slack Bot 전용 API를 구현

 ### 주요 기능
 - **API Key 인증**: X-API-Key 헤더 기반 인증으로 JWT 발급 불필요
 - **보고서 생성 API**: `/api/v1/slack-bot/generate-report` 엔드포인트
 - **Slack 사용자 매핑**: Slack 사용자를 Tyquill User로 매핑
 - **동기 응답**: 완성된 보고서를 즉시 반환

 ### 구현 내용
 - `SlackBotModule`: 독립적인 모듈 구조
 - `SlackBotController`: API 엔드포인트 (생성, 조회, 헬스체크)
 - `SlackBotService`: 비즈니스 로직
 - `SlackReportGeneratorService`: 보고서 생성 전용 로직
 - `ApiKeyAuthGuard`: API Key 검증 Guard
 - DTO: GenerateReportDto, ReportResponseDto, SlackMessageDto, DateRangeDto

 ### 환경 변수
 ```bash
 SLACK_BOT_API_KEY=tyquill-slack-bot-secret-key-2025
 SLACK_BOT_SERVICE_ACCOUNT_ID=1
 ```

 ## 데이터베이스 변경사항
 - `user-oauth.entity.ts`에 Slack OAuth 필드 추가

 ## 빌드 & 배포

 ### 빌드 확인
 - [x] `npm run build` 성공
 - [x] `dist/` 폴더 정상 생성
 - [x] TypeScript 컴파일 에러 없음