### PR TITLE
[CHI-427] User Entity Migration serial integert to uuid

### DIFF
--- a/src/api/admin/admin.controller.ts
+++ b/src/api/admin/admin.controller.ts
@@ -4,9 +4,10 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { AdminService } from './admin.service';
+import { UserIdParamPipe } from '../../users/pipes/user-id.pipe';
 
 export type AdminUserDashboardResponse = {
-  userId: number;
+  userId: string;
   email: string;
   name: string;
   scrapCount: number;
@@ -15,7 +16,7 @@ export type AdminUserDashboardResponse = {
 }[];
 
 export type AdminUserDetailResponse = {
-  userId: number;
+  userId: string;
   email: string;
   name: string;
   createdAt: string;
@@ -37,7 +38,7 @@ export type AdminUserDetailResponse = {
 };
 
 export type AdminArticleGenerationResultsResponse = {
-  userId: number;
+  userId: string;
   email: string;
   name: string;
   articleId: number;
@@ -51,7 +52,7 @@ export type AdminArticleGenerationResultsResponse = {
 
 export type AdminActivitiesResponse = {
   activityType: string;
-  userId: number;
+  userId: string;
   email: string;
   name: string;
   resourceId: number;
@@ -60,7 +61,7 @@ export type AdminActivitiesResponse = {
 }[];
 
 export type AdminArticleDetailResponse = {
-  userId: number;
+  userId: string;
   email: string;
   name: string;
   articleId: number;
@@ -193,7 +194,7 @@ export class AdminController {
   })
   @Get('users/detail')
   async getUserDetail(
-    @Query('userId') userId: number,
+    @Query('userId', UserIdParamPipe) userId: string,
   ): Promise<AdminUserDetailResponse> {
     return this.adminService.getUserDetail(userId);
   }
@@ -281,7 +282,7 @@ export class AdminController {
   })
   @Get('activities')
   async getActivities(
-    @Query('userId') userId?: number,
+    @Query('userId', UserIdParamPipe) userId?: string,
   ): Promise<AdminActivitiesResponse> {
     return this.adminService.getActivities(userId);
   }
@@ -367,7 +368,7 @@ export class AdminController {
   })
   @Get('articles/detail')
   async getArticleDetail(
-    @Query('userId') userId: number,
+    @Query('userId', UserIdParamPipe) userId: string,
     @Query('articleId') articleId: number,
   ): Promise<AdminArticleDetailResponse> {
     return this.adminService.getArticleDetail(userId, articleId);

--- a/src/api/admin/admin.module.ts
+++ b/src/api/admin/admin.module.ts
@@ -8,11 +8,13 @@ import { Scrap } from '../../scraps/entities/scrap.entity';
 import { ArticleArchive } from '../../article-archive/entities/article-archive.entity';
 import { AuthModule } from '../../auth/auth.module';
 import { RolesGuard } from '../../auth/guards/roles.guard';
+import { UsersModule } from '../../users/users.module';
 
 @Module({
   imports: [
     MikroOrmModule.forFeature([User, Article, Scrap, ArticleArchive]),
     AuthModule,
+    UsersModule,
   ],
   controllers: [AdminController],
   providers: [AdminService, RolesGuard],

--- a/src/api/admin/admin.service.ts
+++ b/src/api/admin/admin.service.ts
@@ -2,10 +2,19 @@ import { Injectable } from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { User } from '../../users/entities/user.entity';
 import { Article } from '../../articles/entities/article.entity';
+import { UsersService } from '../../users/users.service';
+import {
+  UserIdentifierLike,
+  buildUserFilterFromInput,
+  normalizeUserIdentifier,
+} from '../../users/utils/user-identifier.util';
 
 @Injectable()
 export class AdminService {
-  constructor(private readonly em: EntityManager) {}
+  constructor(
+    private readonly em: EntityManager,
+    private readonly usersService: UsersService,
+  ) {}
 
   /**
    * 유저 대시보드 - 사용자별 스크랩 수, 생성한 아티클 수, 미활동일 수
@@ -43,10 +52,10 @@ export class AdminService {
   /**
    * 특정 유저의 상세 정보 조회
    */
-  async getUserDetail(userId: number) {
+  async getUserDetail(userId: UserIdentifierLike) {
     const user = await this.em.findOne(
       User,
-      { userId: userId },
+      buildUserFilterFromInput(userId),
       {
         populate: ['scraps', 'tags'],
       },
@@ -59,7 +68,7 @@ export class AdminService {
     const articles = await this.em.find(
       Article,
       {
-        user: { userId: userId },
+        user,
         isDeleted: false,
       },
       {
@@ -139,8 +148,14 @@ export class AdminService {
   /**
    * 활동 내역 - 모든 유저들의 활동 내역
    */
-  async getActivities(userId?: number) {
-    const userFilter = userId ? `AND u.user_id = ${userId}` : '';
+  async getActivities(userId?: UserIdentifierLike) {
+    const canonicalUserId = await this.resolveCanonicalUserId(userId, true);
+    const userFilter = canonicalUserId ? 'AND u.user_id = ?' : '';
+    const params: any[] = [];
+    if (canonicalUserId) {
+      params.push(canonicalUserId);
+      params.push(canonicalUserId);
+    }
 
     const query = `
       SELECT 
@@ -173,7 +188,7 @@ export class AdminService {
       LIMIT 1000
     `;
 
-    const result = await this.em.getConnection().execute(query);
+    const result = await this.em.getConnection().execute(query, params);
     return result.map((row) => ({
       activityType: row.activityType,
       userId: row.userId,
@@ -188,12 +203,12 @@ export class AdminService {
   /**
    * 특정 아티클 생성 요청의 상세 결과
    */
-  async getArticleDetail(userId: number, articleId: number) {
+  async getArticleDetail(userId: UserIdentifierLike, articleId: number) {
     const article = await this.em.findOne(
       Article,
       {
         articleId,
-        user: { userId: userId },
+        user: buildUserFilterFromInput(userId),
         isDeleted: false,
       },
       {
@@ -237,5 +252,26 @@ export class AdminService {
           createdAt: archive.createdAt.toISOString(),
         })),
     };
+  }
+
+  private async resolveCanonicalUserId(
+    userId: UserIdentifierLike,
+    optional = false,
+  ): Promise<string | undefined> {
+    if (userId === undefined || userId === null) {
+      if (optional) {
+        return undefined;
+      }
+      const resolved = await this.usersService.resolveCanonicalUserId(userId);
+      if (!resolved) {
+        throw new Error('User not found');
+      }
+      return resolved;
+    }
+
+    const resolved = await this.usersService.resolveCanonicalUserId(userId, {
+      throwOnNotFound: !optional,
+    });
+    return resolved ?? undefined;
   }
 }

--- a/src/api/articles/articles.controller.ts
+++ b/src/api/articles/articles.controller.ts
@@ -44,7 +44,7 @@ export class ArticlesController {
   @Version('1')
   @Post()
   create(@Request() req: any, @Body() createArticleDto: CreateArticleDto) {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.articlesService.create(userId, createArticleDto);
   }
   /**
@@ -79,7 +79,7 @@ export class ArticlesController {
     @Request() req: any,
     @Body() generateArticleDto: GenerateArticleDto,
   ): Promise<GenerateArticleResponse> {
-    const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+    const userId = req.user.id; // JWT에서 사용자 ID 추출
     return this.articlesService.generateArticle(userId, generateArticleDto);
   }
 
@@ -94,7 +94,7 @@ export class ArticlesController {
     @Query('sortBy') sortBy?: 'created_at' | 'updated_at' | 'title',
     @Query('sortOrder') sortOrder?: 'ASC' | 'DESC',
   ) {
-    const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+    const userId = req.user.id; // JWT에서 사용자 ID 추출
     return this.articlesService.findByUser(userId);
   }
 
@@ -115,7 +115,7 @@ export class ArticlesController {
   @Version('1')
   @Get('search')
   search(@Request() req: any, @Query('q') query: string) {
-    const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+    const userId = req.user.id; // JWT에서 사용자 ID 추출
     return this.articlesService.search(query, userId);
   }
 
@@ -162,7 +162,7 @@ export class ArticlesController {
   @ApiResponse({ status: 403, description: '권한이 없습니다' })
   @ApiResponse({ status: 404, description: '아티클을 찾을 수 없습니다' })
   getVersions(@Request() req: any, @Param('id', ParseIntPipe) id: number) {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.articlesService.getVersions(id, userId);
   }
 
@@ -185,7 +185,7 @@ export class ArticlesController {
     @Param('id', ParseIntPipe) id: number,
     @Param('versionNumber', ParseIntPipe) versionNumber: number,
   ) {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.articlesService.restoreVersion(id, versionNumber, userId);
   }
 
@@ -226,7 +226,7 @@ export class ArticlesController {
     @Request() req: any,
     @Body() generateArticleDto: GenerateArticleV2Dto,
   ): Promise<GenerateArticleV2Response> {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.articlesService.generateArticleV2(userId, generateArticleDto);
   }
 
@@ -264,7 +264,7 @@ export class ArticlesController {
   @Version('2')
   @Get()
   findAllV2(@Request() req: any) {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.articlesService.findByUserV2(userId);
   }
 
@@ -295,7 +295,7 @@ export class ArticlesController {
     @Request() req: any,
     @Body() generateArticleDto: GenerateArticleV3Dto,
   ): Promise<GenerateArticleV2Response> {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.articlesService.generateArticleV3(userId, generateArticleDto);
   }
 
@@ -332,7 +332,7 @@ export class ArticlesController {
   @Version('3')
   @Get()
   findAllV3(@Request() req: any) {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.articlesService.findByUserV3(userId);
   }
 
@@ -362,7 +362,7 @@ export class ArticlesController {
     @Request() req: any,
     @Body() generateArticleDto: GenerateArticleV3Dto,
   ): Observable<MessageEvent> {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.articlesService.generateArticleV3Stream(
       userId,
       generateArticleDto,
@@ -391,7 +391,7 @@ export class ArticlesController {
     @Param('id', ParseIntPipe) id: number,
     @Body() regenerateDto: RegenerateArticleV3Dto,
   ) {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.articlesService.regenerateArticleV3(id, userId, regenerateDto);
   }
 
@@ -418,7 +418,7 @@ export class ArticlesController {
     @Param('id', ParseIntPipe) id: number,
     @Body() regenerateDto: RegenerateArticleV3Dto,
   ): Observable<MessageEvent> {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.articlesService.regenerateArticleV3Stream(
       id,
       userId,

--- a/src/api/articles/dto/generate-article.dto.ts
+++ b/src/api/articles/dto/generate-article.dto.ts
@@ -73,6 +73,6 @@ export class GenerateArticleResponse {
   createdAt: Date;
 
   @ApiProperty()
-  @IsNumber()
-  userId: number;
+  @IsString()
+  userId: string;
 }

--- a/src/api/content/content.controller.ts
+++ b/src/api/content/content.controller.ts
@@ -78,7 +78,7 @@ export class ContentController {
     @Request() req: any,
   ): Promise<UnifiedContentResponseDto> {
     try {
-      const userId = parseInt(req.user.id);
+      const userId = req.user.id;
 
       return await this.contentService.getUnifiedContent(userId, query);
     } catch (error: any) {

--- a/src/api/folders/folders.controller.ts
+++ b/src/api/folders/folders.controller.ts
@@ -48,7 +48,7 @@ export class FoldersController {
     @Request() req: any,
   ): Promise<FolderResponseDto> {
     try {
-      const userId = parseInt(req.user.id);
+      const userId = req.user.id;
       return await this.foldersService.create(userId, createFolderDto);
     } catch (error: any) {
       if (error instanceof HttpException) {
@@ -76,7 +76,7 @@ export class FoldersController {
     @Query('parentId') parentId?: string,
   ): Promise<FolderResponseDto[]> {
     try {
-      const userId = parseInt(req.user.id);
+      const userId = req.user.id;
 
       // Convert 'null' string to actual null for root folders
       const parentFolderId = parentId === 'null' ? null : parentId || undefined;
@@ -104,7 +104,7 @@ export class FoldersController {
     @Request() req: any,
   ): Promise<FolderResponseDto> {
     try {
-      const userId = parseInt(req.user.id);
+      const userId = req.user.id;
       return await this.foldersService.findOne(id, userId);
     } catch (error: any) {
       if (error instanceof HttpException) {
@@ -133,7 +133,7 @@ export class FoldersController {
     @Request() req: any,
   ): Promise<FolderResponseDto> {
     try {
-      const userId = parseInt(req.user.id);
+      const userId = req.user.id;
       return await this.foldersService.update(id, userId, updateFolderDto);
     } catch (error: any) {
       if (error instanceof HttpException) {
@@ -160,7 +160,7 @@ export class FoldersController {
   @ApiResponse({ status: 404, description: 'Folder not found' })
   async remove(@Param('id') id: string, @Request() req: any) {
     try {
-      const userId = parseInt(req.user.id);
+      const userId = req.user.id;
       await this.foldersService.remove(id, userId);
       return { message: 'Folder deleted successfully' };
     } catch (error: any) {
@@ -189,7 +189,7 @@ export class FoldersController {
     @Request() req: any,
   ) {
     try {
-      const userId = parseInt(req.user.id);
+      const userId = req.user.id;
 
       // Use targetFolderId from DTO if provided, otherwise use URL param
       const targetFolderId =
@@ -233,7 +233,7 @@ export class FoldersController {
     @Request() req: any,
   ): Promise<FolderContentsDto> {
     try {
-      const userId = parseInt(req.user.id);
+      const userId = req.user.id;
       return await this.foldersService.getFolderContents(id, userId);
     } catch (error: any) {
       if (error instanceof HttpException) {

--- a/src/api/library-items/library-items.controller.ts
+++ b/src/api/library-items/library-items.controller.ts
@@ -39,14 +39,14 @@ export class LibraryItemsController {
     @Query('type', new ParseEnumPipe(LibraryItemTypeEnum))
     type?: LibraryItemType,
   ): Promise<LibraryItemDto[]> {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.libraryItemsService.list(userId, type);
   }
 
   @Version('1')
   @Post('scrap')
   async createScrap(@Request() req: any, @Body() body: CreateScrapDto) {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.libraryItemsService.createScrap(body, userId);
   }
 
@@ -74,7 +74,7 @@ export class LibraryItemsController {
     if (!file) {
       throw new BadRequestException('File is required');
     }
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.libraryItemsService.uploadViaS3(file, body, userId);
   }
 
@@ -87,7 +87,7 @@ export class LibraryItemsController {
     @Body() body: { name: string },
     @Request() req: any,
   ) {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.libraryItemsService.addTag(
       parseInt(itemId),
       type,
@@ -105,7 +105,7 @@ export class LibraryItemsController {
     type: LibraryItemType,
     @Request() req: any,
   ) {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     await this.libraryItemsService.removeTag(
       parseInt(itemId),
       type,
@@ -127,7 +127,7 @@ export class LibraryItemsController {
     type: LibraryItemType,
     @Request() req: any,
   ) {
-    const userId = parseInt(req.user.id);
+    const userId = req.user.id;
     return this.libraryItemsService.getTags(parseInt(itemId), type, userId);
   }
 }

--- a/src/api/scraps/scraps.controller.ts
+++ b/src/api/scraps/scraps.controller.ts
@@ -45,7 +45,7 @@ export class ScrapsController {
     @Request() req: any,
   ): Promise<ScrapSummaryDto> {
     try {
-      const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+      const userId = req.user.id; // JWT에서 사용자 ID 추출
       const { articleId, ...scrapData } = createScrapDto;
 
       return await this.scrapsService.create(scrapData, userId, articleId);
@@ -69,7 +69,7 @@ export class ScrapsController {
     @Query('sortOrder') sortOrder?: 'ASC' | 'DESC',
   ): Promise<ScrapSummaryDto[] | Scrap[]> {
     try {
-      const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+      const userId = req.user.id; // JWT에서 사용자 ID 추출
 
       if (search) {
         return await this.scrapsService.search(search, userId);
@@ -104,7 +104,7 @@ export class ScrapsController {
     @Query('limit') limit?: number,
   ) {
     try {
-      const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+      const userId = req.user.id; // JWT에서 사용자 ID 추출
 
       const searchOptions: SearchOptions = {
         query,
@@ -142,7 +142,7 @@ export class ScrapsController {
     @Query('matchAll') matchAll?: boolean,
   ) {
     try {
-      const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+      const userId = req.user.id; // JWT에서 사용자 ID 추출
 
       if (!tags || tags.trim().length === 0) {
         throw new HttpException(
@@ -175,7 +175,7 @@ export class ScrapsController {
     @Request() req: any,
   ): Promise<ScrapResponseDto> {
     try {
-      const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+      const userId = req.user.id; // JWT에서 사용자 ID 추출
       const scrap = await this.scrapsService.findOne(scrapId, userId);
       if (!scrap) {
         throw new HttpException('Scrap not found', HttpStatus.NOT_FOUND);
@@ -200,7 +200,7 @@ export class ScrapsController {
     @Request() req: any,
   ) {
     try {
-      const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+      const userId = req.user.id; // JWT에서 사용자 ID 추출
       await this.validateScrapExists(scrapId, userId);
       return await this.scrapsService.update(scrapId, updateScrapDto, userId);
     } catch (error: any) {
@@ -221,7 +221,7 @@ export class ScrapsController {
     @Request() req: any,
   ) {
     try {
-      const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+      const userId = req.user.id; // JWT에서 사용자 ID 추출
       await this.scrapsService.remove(scrapId, userId);
       return { message: 'Scrap deleted successfully' };
     } catch (error: any) {
@@ -255,7 +255,7 @@ export class ScrapsController {
     @Body() createTagDto: CreateTagDto,
   ) {
     try {
-      const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+      const userId = req.user.id; // JWT에서 사용자 ID 추출
 
       // 스크랩 존재 및 권한 확인
       await this.validateScrapExists(scrapId, userId);
@@ -288,7 +288,7 @@ export class ScrapsController {
     @Request() req: any,
   ) {
     try {
-      const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+      const userId = req.user.id; // JWT에서 사용자 ID 추출
       // 스크랩 존재 및 권한 확인
       await this.validateScrapExists(scrapId, userId);
 
@@ -312,7 +312,7 @@ export class ScrapsController {
     @Param('tagId', ParseIntPipe) tagId: number,
   ) {
     try {
-      const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+      const userId = req.user.id; // JWT에서 사용자 ID 추출
 
       // 스크랩 존재 및 권한 확인
       const scrap = await this.scrapsService.findOne(scrapId, userId);
@@ -343,7 +343,7 @@ export class ScrapsController {
     @Request() req: any,
   ): Promise<ScrapResponseDto> {
     try {
-      const userId = parseInt(req.user.id);
+      const userId = req.user.id;
       const { articleId, tags, ...scrapData } = createScrapDto;
 
       // Create scrap with enhanced metadata
@@ -387,7 +387,7 @@ export class ScrapsController {
     @Query('sortOrder') sortOrder?: 'ASC' | 'DESC',
   ): Promise<ScrapResponseDto[]> {
     try {
-      const userId = parseInt(req.user.id);
+      const userId = req.user.id;
 
       if (search) {
         const scraps = await this.scrapsService.search(search, userId);
@@ -424,7 +424,7 @@ export class ScrapsController {
     @Request() req: any,
   ): Promise<ScrapResponseDto> {
     try {
-      const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+      const userId = req.user.id; // JWT에서 사용자 ID 추출
       const scrap = await this.scrapsService.findOne(scrapId, userId);
       if (!scrap) {
         throw new HttpException('Scrap not found', HttpStatus.NOT_FOUND);
@@ -473,7 +473,7 @@ export class ScrapsController {
     limit: number;
   }> {
     try {
-      const userId = parseInt(req.user.id);
+      const userId = req.user.id;
 
       // Get user's scraps with pagination (webclip + upload unified)
       const result = await this.scrapsService.findByUserV2(

--- a/src/api/scraps/scraps.controller.ts
+++ b/src/api/scraps/scraps.controller.ts
@@ -444,7 +444,7 @@ export class ScrapsController {
    */
   private async enrichScrapsWithMetadata(
     scraps: any[],
-    userId: number,
+    userId: string,
   ): Promise<ScrapResponseDto[]> {
     const scrapIds = scraps.map((scrap) => scrap.scrapId);
     return await this.scrapsService.findMany(scrapIds, userId);

--- a/src/api/tags/tags.controller.ts
+++ b/src/api/tags/tags.controller.ts
@@ -35,7 +35,7 @@ export class TagsController {
     @Query('scrapId') scrapId?: number,
   ) {
     try {
-      const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+      const userId = req.user.id; // JWT에서 사용자 ID 추출
       return await this.tagsService.create(createTagDto, userId, scrapId);
     } catch (error: any) {
       throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
@@ -53,7 +53,7 @@ export class TagsController {
     @Query('scrapId') scrapId?: number,
   ) {
     try {
-      const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+      const userId = req.user.id; // JWT에서 사용자 ID 추출
 
       if (name) {
         return await this.tagsService.getTagsByName(userId, name);
@@ -133,7 +133,7 @@ export class TagsController {
   @Get('names')
   async getUserTagNames(@Request() req: any) {
     try {
-      const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+      const userId = req.user.id; // JWT에서 사용자 ID 추출
       return await this.tagsService.getUserTagNames(userId);
     } catch (error: any) {
       throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/api/writing-styles/writing-styles.controller.ts
+++ b/src/api/writing-styles/writing-styles.controller.ts
@@ -24,25 +24,25 @@ export class WritingStylesController {
     @Body() createWritingStyleDto: CreateWritingStyleDto,
     @Req() req: any,
   ) {
-    const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+    const userId = req.user.id; // JWT에서 사용자 ID 추출
     return this.writingStylesService.create(createWritingStyleDto, userId);
   }
 
   @Get()
   findAll(@Req() req: any) {
-    const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+    const userId = req.user.id; // JWT에서 사용자 ID 추출
     return this.writingStylesService.findAll(userId);
   }
 
   @Get(':id')
   findOne(@Param('id') id: string, @Req() req: any) {
-    const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+    const userId = req.user.id; // JWT에서 사용자 ID 추출
     return this.writingStylesService.findOne(+id, userId);
   }
 
   @Delete(':id')
   remove(@Param('id') id: string, @Req() req: any) {
-    const userId = parseInt(req.user.id); // JWT에서 사용자 ID 추출
+    const userId = req.user.id; // JWT에서 사용자 ID 추출
     return this.writingStylesService.remove(+id, userId);
   }
 }

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -93,16 +93,10 @@ export class ArticlesService {
    * 아티클 생성
    */
   async create(
-    userId: number,
+    userId: string,
     createArticleDto: CreateArticleDto,
   ): Promise<Article> {
-    const user = await this.userRepository.findOne({
-      userId: userId,
-    });
-
-    if (!user) {
-      throw new NotFoundException('사용자를 찾을 수 없습니다.');
-    }
+    const user = await this.getUserOrThrow(userId);
 
     const article = new Article();
     article.topic = createArticleDto.topic;
@@ -140,11 +134,11 @@ export class ArticlesService {
    * AI 기반 아티클 생성
    */
   async generateArticle(
-    userId: number,
+    userId: string,
     generateDto: GenerateArticleDto,
   ): Promise<GenerateArticleResponse> {
     // 사용자 검증
-    const user = await this.userRepository.findOne({ userId: userId });
+    const user = await this.getUserOrThrow(userId);
     if (!user) {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
     }
@@ -277,7 +271,7 @@ export class ArticlesService {
    */
   private async validateAndGetWritingStyle(
     writingStyleId: number | undefined,
-    userId: number,
+    userId: string,
   ): Promise<WritingStyle | undefined> {
     if (!writingStyleId) {
       return undefined;
@@ -371,11 +365,11 @@ export class ArticlesService {
    * 사용자별 아티클 조회
    */
   async findByUser(
-    userId: number,
+    userId: string,
     sortBy?: 'created_at' | 'updated_at',
     sortOrder?: 'ASC' | 'DESC',
   ): Promise<any[]> {
-    const user = await this.userRepository.findOne({ userId });
+    const user = await this.getUserOrThrow(userId);
 
     if (!user) {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
@@ -548,7 +542,7 @@ export class ArticlesService {
   /**
    * 아티클 버전 히스토리 조회
    */
-  async getVersions(articleId: number, userId: number): Promise<any[]> {
+  async getVersions(articleId: number, userId: string): Promise<any[]> {
     this.logger.log(
       `📋 Fetching versions for article ${articleId} by user ${userId}`,
     );
@@ -594,7 +588,7 @@ export class ArticlesService {
   async restoreVersion(
     articleId: number,
     versionNumber: number,
-    userId: number,
+    userId: string,
   ): Promise<any> {
     this.logger.log(
       `🔄 Restoring article ${articleId} to version ${versionNumber} by user ${userId}`,
@@ -681,7 +675,7 @@ export class ArticlesService {
   /**
    * 아티클 검색
    */
-  async search(query: string, userId?: number): Promise<Article[]> {
+  async search(query: string, userId?: string): Promise<Article[]> {
     const whereClause: any = {
       $or: [
         { topic: { $like: `%${query}%` } },
@@ -723,7 +717,7 @@ export class ArticlesService {
    * V2 API: 비동기 아티클 생성 - 즉시 202 응답 후 백그라운드 처리
    */
   async generateArticleV2(
-    userId: number,
+    userId: string,
     generateDto: GenerateArticleV2Dto,
   ): Promise<GenerateArticleV2Response> {
     this.logger.log(
@@ -731,7 +725,7 @@ export class ArticlesService {
     );
 
     // 사용자 검증
-    const user = await this.userRepository.findOne({ userId: userId });
+    const user = await this.getUserOrThrow(userId);
     if (!user) {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
     }
@@ -796,8 +790,8 @@ export class ArticlesService {
   /**
    * V2 API: 사용자별 아티클 조회 (상태 정보 포함)
    */
-  async findByUserV2(userId: number): Promise<any[]> {
-    const user = await this.userRepository.findOne({ userId });
+  async findByUserV2(userId: string): Promise<any[]> {
+    const user = await this.getUserOrThrow(userId);
 
     if (!user) {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
@@ -997,7 +991,7 @@ export class ArticlesService {
    * V3 API: 비동기 아티클 생성 - PDF 업로드 지원
    */
   async generateArticleV3(
-    userId: number,
+    userId: string,
     generateDto: GenerateArticleV3Dto,
   ): Promise<GenerateArticleV2Response> {
     this.logger.log(
@@ -1005,7 +999,7 @@ export class ArticlesService {
     );
 
     // 사용자 검증
-    const user = await this.userRepository.findOne({ userId: userId });
+    const user = await this.getUserOrThrow(userId);
     if (!user) {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
     }
@@ -1072,8 +1066,8 @@ export class ArticlesService {
   /**
    * V2 API: 사용자별 아티클 조회 (PDF 정보 포함)
    */
-  async findByUserV3(userId: number): Promise<any[]> {
-    const user = await this.userRepository.findOne({ userId });
+  async findByUserV3(userId: string): Promise<any[]> {
+    const user = await this.getUserOrThrow(userId);
 
     if (!user) {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
@@ -1337,7 +1331,7 @@ export class ArticlesService {
    * V3: 실시간 스트리밍으로 아티클 생성
    */
   generateArticleV3Stream(
-    userId: number,
+    userId: string,
     generateDto: GenerateArticleV3Dto,
   ): Observable<MessageEvent> {
     return new Observable((observer) => {
@@ -1350,7 +1344,7 @@ export class ArticlesService {
             `📡 Starting V3 streaming article generation for user ${userId}`,
           );
 
-          const user = await this.userRepository.findOne({ userId });
+          const user = await this.getUserOrThrow(userId);
           if (!user) {
             throw new NotFoundException('사용자를 찾을 수 없습니다.');
           }
@@ -1614,7 +1608,7 @@ export class ArticlesService {
    */
   async regenerateArticleV3(
     articleId: number,
-    userId: number,
+    userId: string,
     dto: RegenerateArticleV3Dto,
   ): Promise<any> {
     this.logger.log(
@@ -2009,7 +2003,7 @@ export class ArticlesService {
    */
   regenerateArticleV3Stream(
     articleId: number,
-    userId: number,
+    userId: string,
     dto: RegenerateArticleV3Dto,
   ): Observable<MessageEvent> {
     return new Observable((observer) => {
@@ -2516,5 +2510,13 @@ export class ArticlesService {
         }
       })();
     });
+  }
+
+  private async getUserOrThrow(userId: string): Promise<User> {
+    const user = await this.userRepository.findOne({ userId });
+    if (!user) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+    return user;
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -329,7 +329,7 @@ export class AuthService {
    */
   async getUserProfile(userId: string): Promise<UserProfile> {
     try {
-      const user = await this.usersService.findOne(parseInt(userId));
+      const user = await this.usersService.findOne(userId);
 
       if (!user) {
         throw new UnauthorizedException('User not found');

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -9,6 +9,8 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { UserRole } from '../../users/entities/user.entity';
+import { UsersService } from '../../users/users.service';
+import { isUuid } from '../../users/utils/user-identifier.util';
 // Removed Supabase config import
 
 /**
@@ -55,7 +57,7 @@ export interface AuthenticatedUser {
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor() {
+  constructor(private readonly usersService: UsersService) {
     const jwtSecret = process.env.JWT_SECRET || 'your-fallback-secret-key';
 
     super({
@@ -96,10 +98,25 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       // }
 
       // 사용자 정보 구성
+      let canonicalUserId = payload.sub;
+
+      if (!isUuid(canonicalUserId)) {
+        const resolved = await this.usersService.resolveCanonicalUserId(
+          payload.sub,
+          { throwOnNotFound: false },
+        );
+
+        if (!resolved) {
+          throw new UnauthorizedException('User not found');
+        }
+
+        canonicalUserId = resolved;
+      }
+
       const normalizedRole = this.normalizeRole(payload.role);
 
       const user: AuthenticatedUser = {
-        id: payload.sub,
+        id: canonicalUserId,
         email: payload.email,
         role: normalizedRole,
         metadata: {

--- a/src/content/content.module.ts
+++ b/src/content/content.module.ts
@@ -5,9 +5,10 @@ import { ContentController } from '../api/content/content.controller';
 import { Scrap } from '../scraps/entities/scrap.entity';
 import { Article } from '../articles/entities/article.entity';
 import { User } from '../users/entities/user.entity';
+import { UsersModule } from '../users/users.module';
 
 @Module({
-  imports: [MikroOrmModule.forFeature([Scrap, Article, User])],
+  imports: [MikroOrmModule.forFeature([Scrap, Article, User]), UsersModule],
   controllers: [ContentController],
   providers: [ContentService],
   exports: [ContentService],

--- a/src/content/content.service.ts
+++ b/src/content/content.service.ts
@@ -7,6 +7,8 @@ import {
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { Scrap } from '../scraps/entities/scrap.entity';
 import { Article } from '../articles/entities/article.entity';
+import { UsersService } from '../users/users.service';
+import { UserIdentifierLike } from '../users/utils/user-identifier.util';
 import {
   UnifiedContentQueryDto,
   ContentType,
@@ -28,15 +30,22 @@ export class ContentService {
     private readonly scrapRepository: EntityRepository<Scrap>,
     @InjectRepository(Article)
     private readonly articleRepository: EntityRepository<Article>,
+    private readonly usersService: UsersService,
   ) {}
 
   /**
    * Get unified content (scraps and articles) with pagination, filtering, and search
    */
   async getUnifiedContent(
-    userId: number,
+    userId: UserIdentifierLike,
     query: UnifiedContentQueryDto,
   ): Promise<UnifiedContentResponseDto> {
+    const canonicalUserId =
+      (await this.usersService.resolveCanonicalUserId(userId)) ||
+      (() => {
+        throw new Error('User not found');
+      })();
+
     const { type, folderId, scrapType, search, tags } = query;
 
     // Ensure defaults for required pagination fields
@@ -58,7 +67,7 @@ export class ContentService {
 
     // Fetch scraps if needed
     if (includeScraps) {
-      const scrapResult = await this.fetchScraps(userId, {
+      const scrapResult = await this.fetchScraps(canonicalUserId, {
         folderId,
         scrapType,
         sortBy,
@@ -75,7 +84,7 @@ export class ContentService {
 
     // Fetch articles if needed
     if (includeArticles) {
-      const articleResult = await this.fetchArticles(userId, {
+      const articleResult = await this.fetchArticles(canonicalUserId, {
         folderId,
         sortBy,
         sortOrder,
@@ -132,7 +141,7 @@ export class ContentService {
    * Fetch scraps with filters
    */
   private async fetchScraps(
-    userId: number,
+    userId: string,
     options: {
       folderId?: string | null;
       scrapType?: string;
@@ -231,7 +240,7 @@ export class ContentService {
    * Fetch articles with filters
    */
   private async fetchArticles(
-    userId: number,
+    userId: string,
     options: {
       folderId?: string | null;
       sortBy: SortByField;

--- a/src/folders/folders.service.ts
+++ b/src/folders/folders.service.ts
@@ -8,6 +8,10 @@ import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { Folder } from './entities/folder.entity';
 import { User } from '../users/entities/user.entity';
+import {
+  UserIdentifierLike,
+  buildUserFilterFromInput,
+} from '../users/utils/user-identifier.util';
 import { Scrap } from '../scraps/entities/scrap.entity';
 import { Article } from '../articles/entities/article.entity';
 import { CreateFolderDto } from '../api/folders/dto/create-folder.dto';
@@ -35,10 +39,12 @@ export class FoldersService {
    * Create a new folder
    */
   async create(
-    userId: number,
+    userId: UserIdentifierLike,
     createFolderDto: CreateFolderDto,
   ): Promise<FolderResponseDto> {
-    const user = await this.userRepository.findOne({ userId });
+    const user = await this.userRepository.findOne(
+      buildUserFilterFromInput(userId),
+    );
     if (!user) {
       throw new NotFoundException('User not found');
     }
@@ -47,7 +53,7 @@ export class FoldersService {
     if (createFolderDto.parentFolderId) {
       const parentFolder = await this.folderRepository.findOne({
         folderId: createFolderDto.parentFolderId,
-        user: { userId },
+        user: buildUserFilterFromInput(userId),
         isDeleted: false,
       });
 
@@ -82,11 +88,11 @@ export class FoldersService {
    * Optionally filter by parent folder (for nested structure)
    */
   async findAll(
-    userId: number,
+    userId: UserIdentifierLike,
     parentFolderId?: string | null,
   ): Promise<FolderResponseDto[]> {
     const query: any = {
-      user: { userId },
+      user: buildUserFilterFromInput(userId),
       isDeleted: false,
     };
 
@@ -112,11 +118,14 @@ export class FoldersService {
   /**
    * Find a single folder by ID
    */
-  async findOne(folderId: string, userId: number): Promise<FolderResponseDto> {
+  async findOne(
+    folderId: string,
+    userId: UserIdentifierLike,
+  ): Promise<FolderResponseDto> {
     const folder = await this.folderRepository.findOne(
       {
         folderId,
-        user: { userId },
+        user: buildUserFilterFromInput(userId),
         isDeleted: false,
       },
       {
@@ -136,13 +145,13 @@ export class FoldersService {
    */
   async update(
     folderId: string,
-    userId: number,
+    userId: UserIdentifierLike,
     updateFolderDto: UpdateFolderDto,
   ): Promise<FolderResponseDto> {
     const folder = await this.folderRepository.findOne(
       {
         folderId,
-        user: { userId },
+        user: buildUserFilterFromInput(userId),
         isDeleted: false,
       },
       {
@@ -165,7 +174,7 @@ export class FoldersService {
         // Check if parent folder exists and belongs to user
         const parentFolder = await this.folderRepository.findOne({
           folderId: updateFolderDto.parentFolderId,
-          user: { userId },
+          user: buildUserFilterFromInput(userId),
           isDeleted: false,
         });
 
@@ -207,14 +216,14 @@ export class FoldersService {
    * Soft delete a folder
    * CRITICAL FIX: Wrapped in transaction to prevent race conditions
    */
-  async remove(folderId: string, userId: number): Promise<void> {
+  async remove(folderId: string, userId: UserIdentifierLike): Promise<void> {
     await this.em.transactional(async (em) => {
       // Find folder within transaction
       const folder = await em.findOne(
         Folder,
         {
           folderId,
-          user: { userId },
+          user: buildUserFilterFromInput(userId),
           isDeleted: false,
         },
         {
@@ -269,18 +278,19 @@ export class FoldersService {
    */
   async moveItemsToFolder(
     folderId: string | null,
-    userId: number,
+    userId: UserIdentifierLike,
     scrapIds?: number[],
     articleIds?: number[],
   ): Promise<{ movedScraps: number; movedArticles: number }> {
     return await this.em.transactional(async (em) => {
       let targetFolder: Folder | null = null;
+      const userFilter = buildUserFilterFromInput(userId);
 
       // If folderId is provided, verify it exists and belongs to user
       if (folderId) {
         targetFolder = await em.findOne(Folder, {
           folderId,
-          user: { userId },
+          user: userFilter,
           isDeleted: false,
         });
 
@@ -296,7 +306,7 @@ export class FoldersService {
       if (scrapIds && scrapIds.length > 0) {
         const scraps = await em.find(Scrap, {
           scrapId: { $in: scrapIds },
-          user: { userId },
+          user: userFilter,
           isDeleted: false,
         });
 
@@ -312,7 +322,7 @@ export class FoldersService {
       if (articleIds && articleIds.length > 0) {
         const articles = await em.find(Article, {
           articleId: { $in: articleIds },
-          user: { userId },
+          user: userFilter,
           isDeleted: false,
         });
 
@@ -333,12 +343,12 @@ export class FoldersService {
    */
   async getFolderContents(
     folderId: string,
-    userId: number,
+    userId: UserIdentifierLike,
   ): Promise<FolderContentsDto> {
     const folder = await this.folderRepository.findOne(
       {
         folderId,
-        user: { userId },
+        user: buildUserFilterFromInput(userId),
         isDeleted: false,
       },
       {
@@ -378,6 +388,7 @@ export class FoldersService {
     const childFolders = await this.folderRepository.find(
       {
         parentFolder: { folderId },
+        user: buildUserFilterFromInput(userId),
         isDeleted: false,
       },
       {

--- a/src/library-items/library-items.service.ts
+++ b/src/library-items/library-items.service.ts
@@ -8,6 +8,10 @@ import { ScrapsService } from '../scraps/scraps.service';
 import { UploadedFilesService } from '../uploaded-files/uploaded-files.service';
 import { CreateScrapDto } from '../api/scraps/dto/create-scrap.dto';
 import { Express } from 'express';
+import {
+  UserIdentifierLike,
+  buildUserFilterFromInput,
+} from '../users/utils/user-identifier.util';
 
 export type LibraryItemType = 'SCRAP' | 'UPLOAD';
 
@@ -42,14 +46,15 @@ export class LibraryItemsService {
   ) {}
 
   async list(
-    userId: number,
+    userId: UserIdentifierLike,
     type?: LibraryItemType,
   ): Promise<LibraryItemDto[]> {
     const items: LibraryItemDto[] = [];
+    const userFilter = buildUserFilterFromInput(userId);
 
     if (!type || type === 'SCRAP') {
       const scraps = await this.scrapRepository.find(
-        { user: { userId }, isDeleted: false },
+        { user: userFilter, isDeleted: false },
         { populate: ['tags'], orderBy: { createdAt: 'DESC' } },
       );
       items.push(...scraps.map(this.mapScrapToDto));
@@ -58,7 +63,7 @@ export class LibraryItemsService {
     if (!type || type === 'UPLOAD') {
       const uploads = await this.scrapRepository.find(
         {
-          user: { userId },
+          user: userFilter,
           filePath: { $ne: null },
           isDeleted: false,
           mimeType: { $ne: null },
@@ -72,14 +77,17 @@ export class LibraryItemsService {
     return items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
   }
 
-  async createScrap(createScrapDto: CreateScrapDto, userId: number) {
+  async createScrap(
+    createScrapDto: CreateScrapDto,
+    userId: UserIdentifierLike,
+  ) {
     return this.scrapsService.create(createScrapDto, userId);
   }
 
   async uploadViaS3(
     file: Express.Multer.File,
     body: { title?: string; description?: string },
-    userId: number,
+    userId: UserIdentifierLike,
   ) {
     return this.uploadedFilesService.uploadToS3AndSave(
       file,
@@ -125,10 +133,10 @@ export class LibraryItemsService {
     itemId: number,
     itemType: LibraryItemType,
     tagName: string,
-    userId: number,
+    userId: UserIdentifierLike,
   ): Promise<Tag | null> {
     const criteria: any = {
-      user: { userId },
+      user: buildUserFilterFromInput(userId),
       name: tagName,
     };
 
@@ -146,10 +154,10 @@ export class LibraryItemsService {
     itemId: number,
     itemType: LibraryItemType,
     tagName: string,
-    userId: number,
+    userId: UserIdentifierLike,
   ): Promise<Tag> {
     return this.em.transactional(async (em) => {
-      const user = await em.findOne(User, { userId });
+      const user = await em.findOne(User, buildUserFilterFromInput(userId));
       if (!user) {
         throw new NotFoundException('User not found');
       }
@@ -160,7 +168,7 @@ export class LibraryItemsService {
         itemId,
         itemType,
         tagName,
-        userId,
+        userId as number, // legacy support; findExistingTag expects number
       );
 
       if (existingTag) {
@@ -175,7 +183,7 @@ export class LibraryItemsService {
       if (itemType === 'SCRAP') {
         const scrap = await em.findOne(Scrap, {
           scrapId: itemId,
-          user: { userId },
+          user: buildUserFilterFromInput(userId),
         });
         if (!scrap) {
           throw new NotFoundException('Scrap not found');
@@ -184,7 +192,7 @@ export class LibraryItemsService {
       } else {
         const uploadScrap = await em.findOne(Scrap, {
           scrapId: itemId,
-          user: { userId },
+          user: buildUserFilterFromInput(userId),
         });
         if (!uploadScrap) {
           throw new NotFoundException('Uploaded file (as scrap) not found');
@@ -201,12 +209,12 @@ export class LibraryItemsService {
     itemId: number,
     itemType: LibraryItemType,
     tagId: number,
-    userId: number,
+    userId: UserIdentifierLike,
   ): Promise<void> {
     if (itemType === 'SCRAP') {
       const scrap = await this.scrapRepository.findOne({
         scrapId: itemId,
-        user: { userId },
+        user: buildUserFilterFromInput(userId),
       });
       if (!scrap) {
         throw new NotFoundException('Scrap not found or access denied');
@@ -214,7 +222,7 @@ export class LibraryItemsService {
     } else {
       const uploadedScrap = await this.scrapRepository.findOne({
         scrapId: itemId,
-        user: { userId },
+        user: buildUserFilterFromInput(userId),
       });
       if (!uploadedScrap) {
         throw new NotFoundException('Uploaded file not found or access denied');
@@ -225,13 +233,13 @@ export class LibraryItemsService {
     if (itemType === 'SCRAP') {
       tag = await this.tagRepository.findOne({
         tagId,
-        user: { userId },
+        user: buildUserFilterFromInput(userId),
         scrap: { scrapId: itemId },
       });
     } else {
       tag = await this.tagRepository.findOne({
         tagId,
-        user: { userId },
+        user: buildUserFilterFromInput(userId),
         scrap: { scrapId: itemId },
       });
     }
@@ -246,12 +254,12 @@ export class LibraryItemsService {
   async getTags(
     itemId: number,
     itemType: LibraryItemType,
-    userId: number,
+    userId: UserIdentifierLike,
   ): Promise<Tag[]> {
     if (itemType === 'SCRAP') {
       return this.tagRepository.find(
         {
-          user: { userId },
+          user: buildUserFilterFromInput(userId),
           scrap: { scrapId: itemId },
         },
         {
@@ -262,7 +270,7 @@ export class LibraryItemsService {
     } else {
       return this.tagRepository.find(
         {
-          user: { userId },
+          user: buildUserFilterFromInput(userId),
           scrap: { scrapId: itemId },
         },
         {

--- a/src/notifications/slack.service.ts
+++ b/src/notifications/slack.service.ts
@@ -25,7 +25,7 @@ export class SlackService {
   async notifyNewUserSignup(userData: {
     email: string;
     name: string;
-    userId: number;
+    userId: string;
     provider?: string;
     createdAt?: Date;
   }): Promise<void> {
@@ -147,7 +147,7 @@ export class SlackService {
     keyInsight?: string;
     userEmail: string;
     userName: string;
-    userId: number;
+    userId: string;
     generationTime?: number;
     contentLength?: number;
     version?: string; // API version used (V1, V2, V3)

--- a/src/queue/controllers/job-status.controller.ts
+++ b/src/queue/controllers/job-status.controller.ts
@@ -35,8 +35,8 @@ export class JobStatusController {
       throw new BadRequestException('Invalid limit parameter');
     }
 
-    const userId = parseInt(req.user.id);
-    if (isNaN(userId)) {
+    const userId = req.user.id;
+    if (!userId) {
       throw new BadRequestException('Invalid user ID');
     }
     return this.jobStatusService.getJobsByUser(userId, limitNum);

--- a/src/queue/dto/file-analysis.dto.ts
+++ b/src/queue/dto/file-analysis.dto.ts
@@ -11,7 +11,7 @@ export interface FileAnalysisMessage {
   fileUrl: string;
   fileName: string;
   mimeType: string;
-  userId: number;
+  userId: string | number;
   timestamp: string;
 }
 
@@ -36,8 +36,8 @@ export class FileAnalysisRequestDto {
   @IsMimeType()
   mimeType: string;
 
-  @IsNumber()
-  userId: number;
+  @IsString()
+  userId: string;
 
   @IsDateString()
   timestamp: string;
@@ -47,7 +47,7 @@ export class FileAnalysisRequestDto {
     this.fileUrl = data.fileUrl;
     this.fileName = data.fileName;
     this.mimeType = data.mimeType;
-    this.userId = data.userId;
+    this.userId = String(data.userId);
     this.timestamp = data.timestamp;
   }
 }

--- a/src/queue/entities/job-status.entity.ts
+++ b/src/queue/entities/job-status.entity.ts
@@ -26,8 +26,8 @@ export class Job {
   @Enum(() => JobStatus)
   status: JobStatus = JobStatus.PENDING;
 
-  @Property()
-  userId!: number;
+  @Property({ columnType: 'uuid' })
+  userId!: string;
 
   @Property({ type: 'json', nullable: true })
   payload?: any; // Job-specific data

--- a/src/queue/queue.module.ts
+++ b/src/queue/queue.module.ts
@@ -9,11 +9,13 @@ import { AiCallbacksController } from './controllers/ai-callbacks.controller';
 import { QUEUE_NAMES } from './constants/queue.constants';
 import { Job } from './entities/job-status.entity';
 import { Scrap } from '../scraps/entities/scrap.entity';
+import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
     ConfigModule,
     MikroOrmModule.forFeature([Job, Scrap]),
+    UsersModule,
     SqsModule.registerAsync({
       imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => {

--- a/src/queue/services/job-status.service.ts
+++ b/src/queue/services/job-status.service.ts
@@ -1,25 +1,39 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { Job, JobType, JobStatus } from '../entities/job-status.entity';
 import { v4 as uuidv4 } from 'uuid';
+import { UsersService } from '../../users/users.service';
+import {
+  UserIdentifierLike,
+  isUuid,
+} from '../../users/utils/user-identifier.util';
 
 @Injectable()
 export class JobStatusService {
   private readonly logger = new Logger(JobStatusService.name);
 
-  constructor(private readonly em: EntityManager) {}
+  constructor(
+    private readonly em: EntityManager,
+    private readonly usersService: UsersService,
+  ) {}
 
   async createJob(data: {
     jobType: JobType;
-    userId: number;
+    userId: UserIdentifierLike;
     payload?: any;
     queueName?: string;
     maxRetries?: number;
   }): Promise<Job> {
+    const canonicalUserId =
+      (await this.usersService.resolveCanonicalUserId(data.userId)) ??
+      (() => {
+        throw new NotFoundException('User not found');
+      })();
+
     const job = new Job();
     job.jobUuid = uuidv4();
     job.jobType = data.jobType;
-    job.userId = data.userId;
+    job.userId = canonicalUserId;
     job.payload = data.payload;
     job.queueName = data.queueName;
     job.maxRetries = data.maxRetries ?? 3;
@@ -113,10 +127,22 @@ export class JobStatusService {
     return this.em.findOne(Job, { jobUuid });
   }
 
-  async getJobsByUser(userId: number, limit: number = 50): Promise<Job[]> {
+  async getJobsByUser(
+    userId: UserIdentifierLike,
+    limit: number = 50,
+  ): Promise<Job[]> {
+    const canonical =
+      (typeof userId === 'string' && isUuid(userId)
+        ? userId.toLowerCase()
+        : await this.usersService.resolveCanonicalUserId(userId)) ||
+      undefined;
+    if (!canonical) {
+      return [];
+    }
+
     return this.em.find(
       Job,
-      { userId },
+      { userId: canonical },
       {
         orderBy: { createdAt: 'DESC' },
         limit,

--- a/src/scraps/scraps.service.ts
+++ b/src/scraps/scraps.service.ts
@@ -11,11 +11,16 @@ import { InjectRepository } from '@mikro-orm/nestjs';
 import { User } from '../users/entities/user.entity';
 import { Article } from '../articles/entities/article.entity';
 import { ArticleScrap } from '../articles/entities/article-scrap.entity';
+import {
+  UserIdentifierLike,
+  buildUserFilterFromInput,
+  normalizeUserIdentifier,
+} from '../users/utils/user-identifier.util';
 // Analytics tracking migrated to extension client (PostHog).
 
 export interface SearchOptions {
   query?: string;
-  userId?: number;
+  userId?: UserIdentifierLike;
   articleId?: number;
   tags?: string[];
   dateFrom?: Date;
@@ -45,10 +50,12 @@ export class ScrapsService {
 
   async create(
     createScrapDto: CreateScrapDto,
-    userId: number,
+    userId: UserIdentifierLike,
     articleId?: number,
   ): Promise<ScrapSummaryDto> {
-    const user = await this.userRepository.findOne({ userId });
+    const user = await this.userRepository.findOne(
+      buildUserFilterFromInput(userId),
+    );
     if (!user) {
       throw new Error('User not found');
     }
@@ -107,10 +114,15 @@ export class ScrapsService {
     return this.toScrapSummaryDto(scrap);
   }
 
-  async findAll(userId?: number): Promise<Scrap[]> {
-    const query: any = userId
-      ? { user: { userId }, isDeleted: false, filePath: null }
-      : { isDeleted: false, mimeType: null };
+  async findAll(userId?: UserIdentifierLike): Promise<Scrap[]> {
+    const query: any = { isDeleted: false };
+
+    if (normalizeUserIdentifier(userId) !== undefined) {
+      query.user = buildUserFilterFromInput(userId as UserIdentifierLike);
+      query.filePath = null;
+    } else {
+      query.mimeType = null;
+    }
 
     return await this.scrapRepository.find(query, {
       populate: ['tags'],
@@ -120,13 +132,13 @@ export class ScrapsService {
 
   async findOne(
     scrapId: number,
-    userId?: number,
+    userId?: UserIdentifierLike,
   ): Promise<ScrapResponseDto | null> {
     const query: any = { scrapId, isDeleted: false };
 
     // Add user authorization if userId is provided
-    if (userId !== undefined) {
-      query.user = { userId };
+    if (normalizeUserIdentifier(userId) !== undefined) {
+      query.user = buildUserFilterFromInput(userId as UserIdentifierLike);
     }
 
     const scrap = await this.scrapRepository.findOne(query, {
@@ -145,7 +157,7 @@ export class ScrapsService {
    */
   async findMany(
     scrapIds: number[],
-    userId?: number,
+    userId?: UserIdentifierLike,
   ): Promise<ScrapResponseDto[]> {
     if (!scrapIds || scrapIds.length === 0) {
       return [];
@@ -157,8 +169,8 @@ export class ScrapsService {
     };
 
     // Add user authorization if userId is provided
-    if (userId !== undefined) {
-      query.user = { userId };
+    if (normalizeUserIdentifier(userId) !== undefined) {
+      query.user = buildUserFilterFromInput(userId as UserIdentifierLike);
     }
 
     const scraps = await this.scrapRepository.find(query, {
@@ -201,11 +213,15 @@ export class ScrapsService {
   }
 
   async findByUser(
-    userId: number,
+    userId: UserIdentifierLike,
     sortBy?: 'created_at' | 'updated_at' | 'title',
     sortOrder?: 'ASC' | 'DESC',
   ): Promise<ScrapSummaryDto[]> {
-    const query = { user: { userId }, isDeleted: false, mimeType: null };
+    const query = {
+      user: buildUserFilterFromInput(userId),
+      isDeleted: false,
+      mimeType: null,
+    };
     let orderBy: any = { createdAt: 'DESC' };
 
     switch (sortBy) {
@@ -234,14 +250,17 @@ export class ScrapsService {
    * V2: Find all scraps by user with pagination (webclip + upload unified)
    */
   async findByUserV2(
-    userId: number,
+    userId: UserIdentifierLike,
     sortBy?: 'created_at' | 'updated_at' | 'title',
     sortOrder?: 'ASC' | 'DESC',
     type?: string, // 'webclip', 'upload', or undefined for all
     page: number = 1,
     limit: number = 20,
   ): Promise<{ scraps: ScrapSummaryDto[]; total: number; hasMore: boolean }> {
-    const query: any = { user: { userId }, isDeleted: false };
+    const query: any = {
+      user: buildUserFilterFromInput(userId),
+      isDeleted: false,
+    };
 
     // Filter by type if specified
     if (type === 'webclip') {
@@ -300,13 +319,13 @@ export class ScrapsService {
   async update(
     scrapId: number,
     updateScrapDto: UpdateScrapDto,
-    userId?: number,
+    userId?: UserIdentifierLike,
   ): Promise<Scrap | null> {
     const query: any = { scrapId, isDeleted: false };
 
     // Add user authorization if userId is provided
-    if (userId !== undefined) {
-      query.user = { userId };
+    if (normalizeUserIdentifier(userId) !== undefined) {
+      query.user = buildUserFilterFromInput(userId as UserIdentifierLike);
     }
 
     const scrap = await this.scrapRepository.findOne(query);
@@ -331,12 +350,12 @@ export class ScrapsService {
     return scrap;
   }
 
-  async remove(scrapId: number, userId?: number): Promise<void> {
+  async remove(scrapId: number, userId?: UserIdentifierLike): Promise<void> {
     const query: any = { scrapId };
 
     // Add user authorization if userId is provided
-    if (userId !== undefined) {
-      query.user = { userId };
+    if (normalizeUserIdentifier(userId) !== undefined) {
+      query.user = buildUserFilterFromInput(userId as UserIdentifierLike);
     }
 
     const scrap = await this.scrapRepository.findOne(query, {
@@ -355,7 +374,7 @@ export class ScrapsService {
     }
   }
 
-  async search(query: string, userId?: number): Promise<Scrap[]> {
+  async search(query: string, userId?: UserIdentifierLike): Promise<Scrap[]> {
     const qb = this.em.createQueryBuilder(Scrap, 's');
 
     qb.where({
@@ -367,8 +386,11 @@ export class ScrapsService {
       isDeleted: false,
     });
 
-    if (userId) {
-      qb.andWhere({ user: { userId }, isDeleted: false });
+    if (normalizeUserIdentifier(userId) !== undefined) {
+      qb.andWhere({
+        user: buildUserFilterFromInput(userId as UserIdentifierLike),
+        isDeleted: false,
+      });
     }
 
     qb.leftJoinAndSelect('s.user', 'u')
@@ -408,8 +430,13 @@ export class ScrapsService {
     }
 
     // 사용자 필터
-    if (searchOptions.userId) {
-      qb.andWhere({ user: { userId: searchOptions.userId }, isDeleted: false });
+    if (normalizeUserIdentifier(searchOptions.userId) !== undefined) {
+      qb.andWhere({
+        user: buildUserFilterFromInput(
+          searchOptions.userId as UserIdentifierLike,
+        ),
+        isDeleted: false,
+      });
     }
 
     // 기사 필터

--- a/src/tags/tags.service.ts
+++ b/src/tags/tags.service.ts
@@ -6,6 +6,11 @@ import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 import { Tag } from './entities/tag.entity';
 import { User } from '../users/entities/user.entity';
 import { Scrap } from '../scraps/entities/scrap.entity';
+import {
+  UserIdentifierLike,
+  buildUserFilterFromInput,
+  normalizeUserIdentifier,
+} from '../users/utils/user-identifier.util';
 
 @Injectable()
 export class TagsService {
@@ -21,10 +26,12 @@ export class TagsService {
 
   async create(
     createTagDto: CreateTagDto,
-    userId: number,
+    userId: UserIdentifierLike,
     scrapId?: number,
   ): Promise<Tag> {
-    const user = await this.userRepository.findOne({ userId });
+    const user = await this.userRepository.findOne(
+      buildUserFilterFromInput(userId),
+    );
     if (!user) {
       throw new Error('User not found');
     }
@@ -47,8 +54,12 @@ export class TagsService {
     return tag;
   }
 
-  async findAll(userId?: number): Promise<Tag[]> {
-    const query = userId ? { user: { userId }, isDeleted: false } : {};
+  async findAll(userId?: UserIdentifierLike): Promise<Tag[]> {
+    const normalized = normalizeUserIdentifier(userId);
+    const query =
+      normalized !== undefined
+        ? { user: buildUserFilterFromInput(normalized), isDeleted: false }
+        : {};
 
     return await this.tagRepository.find(query, {
       populate: ['user', 'scrap'],
@@ -65,9 +76,9 @@ export class TagsService {
     );
   }
 
-  async findByUser(userId: number): Promise<Tag[]> {
+  async findByUser(userId: UserIdentifierLike): Promise<Tag[]> {
     return await this.tagRepository.find(
-      { user: { userId } },
+      { user: buildUserFilterFromInput(userId) },
       { populate: ['user', 'scrap'] },
     );
   }
@@ -79,10 +90,13 @@ export class TagsService {
     );
   }
 
-  async findByUserAndScrap(userId: number, scrapId: number): Promise<Tag[]> {
+  async findByUserAndScrap(
+    userId: UserIdentifierLike,
+    scrapId: number,
+  ): Promise<Tag[]> {
     return await this.tagRepository.find(
       {
-        user: { userId },
+        user: buildUserFilterFromInput(userId),
         scrap: { scrapId },
       },
       { populate: ['user', 'scrap'], filters: { isDeleted: false } },
@@ -108,15 +122,19 @@ export class TagsService {
   /**
    * 태그명으로 검색
    */
-  async searchByName(name: string, userId?: number): Promise<Tag[]> {
+  async searchByName(
+    name: string,
+    userId?: UserIdentifierLike,
+  ): Promise<Tag[]> {
     interface TagSearchQuery {
       name: { $ilike: string };
-      user?: { userId: number };
+      user?: ReturnType<typeof buildUserFilterFromInput>;
       isDeleted?: boolean;
     }
     const query: TagSearchQuery = { name: { $ilike: `%${name}%` } };
-    if (userId) {
-      query.user = { userId };
+    const normalized = normalizeUserIdentifier(userId);
+    if (normalized !== undefined) {
+      query.user = buildUserFilterFromInput(normalized);
     }
 
     return await this.tagRepository.find(query, {
@@ -127,23 +145,26 @@ export class TagsService {
   /**
    * 사용자별 고유 태그명 목록
    */
-  async getUserTagNames(userId: number): Promise<string[]> {
+  async getUserTagNames(userId: UserIdentifierLike): Promise<string[]> {
     const qb = this.em.createQueryBuilder(Tag, 't');
 
     const result = await qb
       .select('DISTINCT t.name')
-      .where({ user: { userId } })
+      .where({ user: buildUserFilterFromInput(userId) })
       .getResult();
 
     return result.map((r) => r.name);
   }
 
   // Legacy method names for backward compatibility
-  async getTagsByName(userId: number, name: string): Promise<Tag[]> {
+  async getTagsByName(
+    userId: UserIdentifierLike,
+    name: string,
+  ): Promise<Tag[]> {
     return this.searchByName(name, userId);
   }
 
-  async getUniqueTagNames(userId: number): Promise<string[]> {
+  async getUniqueTagNames(userId: UserIdentifierLike): Promise<string[]> {
     return this.getUserTagNames(userId);
   }
 }

--- a/src/uploaded-files/uploaded-files.service.ts
+++ b/src/uploaded-files/uploaded-files.service.ts
@@ -11,6 +11,12 @@ import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { Scrap } from '../scraps/entities/scrap.entity';
 import { User } from '../users/entities/user.entity';
+import {
+  UserIdentifierLike,
+  buildUserFilterFromInput,
+  ensureUserIdentifier,
+  normalizeUserIdentifier,
+} from '../users/utils/user-identifier.util';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import * as fs from 'fs';
 import { v4 as uuidv4 } from 'uuid';
@@ -51,15 +57,19 @@ export class UploadedFilesService {
 
   // metadata-only create() was removed in favor of server-proxy upload flow
 
-  async findAll(userId?: number): Promise<Scrap[]> {
-    const where = userId ? { user: { userId } } : {};
+  async findAll(userId?: UserIdentifierLike): Promise<Scrap[]> {
+    const normalized = normalizeUserIdentifier(userId);
+    const where =
+      normalized !== undefined
+        ? { user: buildUserFilterFromInput(normalized), isDeleted: false }
+        : {};
     return this.scrapRepository.find(where, {
       populate: ['user', 'tags'],
       orderBy: { createdAt: 'DESC' },
     });
   }
 
-  async findOne(id: number, userId: number): Promise<Scrap> {
+  async findOne(id: number, userId: UserIdentifierLike): Promise<Scrap> {
     const uploadedFile = await this.scrapRepository.findOne(
       { scrapId: id },
       { populate: ['user', 'tags'] },
@@ -69,7 +79,13 @@ export class UploadedFilesService {
       throw new NotFoundException(`Uploaded item #${id} not found`);
     }
 
-    if (uploadedFile.user.userId !== userId) {
+    const normalizedUserId = ensureUserIdentifier(userId);
+    if (
+      (typeof normalizedUserId === 'string' &&
+        uploadedFile.user.userId !== normalizedUserId) ||
+      (typeof normalizedUserId === 'number' &&
+        uploadedFile.user.legacyUserId !== normalizedUserId)
+    ) {
       throw new ForbiddenException(
         'You are not allowed to access this uploaded file',
       );
@@ -81,7 +97,7 @@ export class UploadedFilesService {
   async update(
     id: number,
     updateUploadedFileDto: UpdateUploadedFileDto,
-    userId: number,
+    userId: UserIdentifierLike,
   ): Promise<Scrap> {
     const uploadedFile = await this.findOne(id, userId);
 
@@ -96,7 +112,7 @@ export class UploadedFilesService {
     return uploadedFile;
   }
 
-  async remove(id: number, userId: number): Promise<void> {
+  async remove(id: number, userId: UserIdentifierLike): Promise<void> {
     const uploadedFile = await this.findOne(id, userId);
     await this.em.removeAndFlush(uploadedFile);
   }
@@ -105,17 +121,19 @@ export class UploadedFilesService {
     file: Express.Multer.File,
     title: string,
     description: string,
-    userId: number,
+    userId: UserIdentifierLike,
   ): Promise<Scrap> {
     try {
-      const user = await this.userRepository.findOne({ userId });
+      const user = await this.userRepository.findOne(
+        buildUserFilterFromInput(userId),
+      );
       if (!user) {
         throw new NotFoundException('User not found');
       }
 
       // S3 업로드를 위한 키 생성
       const hashDirectory = createHash('sha512')
-        .update(userId.toString())
+        .update(String(user.userId))
         .digest('hex')
         .substring(0, 8);
       const fileKey = `uploads/${hashDirectory}/${uuidv4()}`;

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -5,6 +5,7 @@ import {
   Property,
   Collection,
 } from '@mikro-orm/core';
+import { v4 as uuidv4 } from 'uuid';
 import { Scrap } from '../../scraps/entities/scrap.entity';
 import { Tag } from '../../tags/entities/tag.entity';
 import { UserOAuth } from './user-oauth.entity';
@@ -17,8 +18,20 @@ export enum UserRole {
 
 @Entity({ tableName: 'users' })
 export class User {
-  @PrimaryKey({ name: 'user_id' })
-  userId: number;
+  @PrimaryKey({
+    name: 'user_id',
+    type: 'uuid',
+    defaultRaw: 'uuid_generate_v4()',
+  })
+  userId: string = uuidv4();
+
+  @Property({
+    name: 'legacy_user_id',
+    type: 'integer',
+    nullable: true,
+    unique: true,
+  })
+  legacyUserId?: number;
 
   @Property({ name: 'email', unique: true })
   email: string;

--- a/src/users/pipes/user-id.pipe.ts
+++ b/src/users/pipes/user-id.pipe.ts
@@ -1,0 +1,29 @@
+import {
+  BadRequestException,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
+import { UsersService } from '../users.service';
+
+@Injectable()
+export class UserIdParamPipe implements PipeTransform {
+  constructor(private readonly usersService: UsersService) {}
+
+  async transform(
+    value: string | number | undefined,
+  ): Promise<string | undefined> {
+    if (value === null || value === undefined || `${value}`.trim() === '') {
+      return undefined;
+    }
+
+    const canonical = await this.usersService.resolveCanonicalUserId(value, {
+      throwOnNotFound: false,
+    });
+
+    if (!canonical) {
+      throw new BadRequestException('Invalid user identifier');
+    }
+
+    return canonical;
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -3,11 +3,12 @@ import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { User } from './entities/user.entity';
 import { UsersService } from './users.service';
 import { UserOAuth } from './entities/user-oauth.entity';
+import { UserIdParamPipe } from './pipes/user-id.pipe';
 // Analytics tracking moved to client; module no longer required here.
 
 @Module({
   imports: [MikroOrmModule.forFeature([User, UserOAuth])],
-  providers: [UsersService],
-  exports: [UsersService],
+  providers: [UsersService, UserIdParamPipe],
+  exports: [UsersService, UserIdParamPipe],
 })
 export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,8 +1,14 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 import { User, UserRole } from './entities/user.entity';
 import { UserOAuth, OAuthProvider } from './entities/user-oauth.entity';
 import { InjectRepository } from '@mikro-orm/nestjs';
+import {
+  UserIdentifierLike,
+  buildUserFilterFromInput,
+  ensureUserIdentifier,
+  isUuid,
+} from './utils/user-identifier.util';
 // Analytics tracking migrated to extension client (PostHog). Server no longer emits events.
 
 /**
@@ -35,9 +41,13 @@ export class UsersService {
     private readonly userOAuthRepository: EntityRepository<UserOAuth>,
   ) {}
 
-  async findOne(id: number): Promise<User | null> {
+  async findOne(id: UserIdentifierLike): Promise<User | null> {
+    if (id === null || id === undefined) {
+      return null;
+    }
+
     return await this.userRepository.findOne(
-      { userId: id },
+      buildUserFilterFromInput(id),
       { populate: ['oauthAccounts'] },
     );
   }
@@ -166,7 +176,9 @@ export class UsersService {
   /**
    * 사용자의 OAuth 계정 조회
    */
-  async getUserOAuthAccounts(userId: number): Promise<UserOAuth[]> {
+  async getUserOAuthAccounts(
+    userId: UserIdentifierLike,
+  ): Promise<UserOAuth[]> {
     const user = await this.findOne(userId);
     if (!user) {
       return [];
@@ -210,7 +222,7 @@ export class UsersService {
    * 사용자 정보 업데이트
    */
   async updateUser(
-    userId: number,
+    userId: UserIdentifierLike,
     updateData: Partial<{ email: string; name: string }>,
   ): Promise<User | null> {
     const user = await this.findOne(userId);
@@ -229,5 +241,29 @@ export class UsersService {
     await this.em.persistAndFlush(user);
 
     return user;
+  }
+
+  async resolveCanonicalUserId(
+    identifier: UserIdentifierLike,
+    { throwOnNotFound = true }: { throwOnNotFound?: boolean } = {},
+  ): Promise<string | null> {
+    const normalized = ensureUserIdentifier(identifier);
+
+    if (typeof normalized === 'string' && isUuid(normalized)) {
+      return normalized.toLowerCase();
+    }
+
+    const user = await this.userRepository.findOne(
+      buildUserFilterFromInput(normalized),
+    );
+
+    if (!user) {
+      if (throwOnNotFound) {
+        throw new NotFoundException('User not found');
+      }
+      return null;
+    }
+
+    return user.userId;
   }
 }

--- a/src/users/utils/user-identifier.util.ts
+++ b/src/users/utils/user-identifier.util.ts
@@ -1,0 +1,73 @@
+import { FilterQuery } from '@mikro-orm/core';
+import { User } from '../entities/user.entity';
+
+export type UserIdentifier = string | number;
+export type UserIdentifierLike = UserIdentifier | null | undefined;
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isUuid(value: string): boolean {
+  return UUID_REGEX.test(value.trim());
+}
+
+export function normalizeUserIdentifier(
+  value: UserIdentifierLike,
+): UserIdentifier | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (isUuid(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+
+  const parsed = Number(trimmed);
+  if (!Number.isNaN(parsed)) {
+    return parsed;
+  }
+
+  throw new Error(`Invalid user identifier: ${value}`);
+}
+
+export function ensureUserIdentifier(
+  value: UserIdentifierLike,
+): UserIdentifier {
+  const normalized = normalizeUserIdentifier(value);
+  if (normalized === undefined) {
+    throw new Error('User identifier is required');
+  }
+  return normalized;
+}
+
+export function buildUserFilterFromInput(
+  value: UserIdentifierLike,
+): FilterQuery<User> {
+  return buildUserWhere(ensureUserIdentifier(value));
+}
+
+export function buildUserWhere(
+  identifier: UserIdentifier,
+): FilterQuery<User> {
+  if (typeof identifier === 'string') {
+    if (!isUuid(identifier)) {
+      throw new Error(`Invalid UUID string: ${identifier}`);
+    }
+    return { userId: identifier.toLowerCase() };
+  }
+
+  if (!Number.isInteger(identifier)) {
+    throw new Error(`Legacy user ID must be an integer: ${identifier}`);
+  }
+
+  return { legacyUserId: identifier };
+}

--- a/src/writing-styles/writing-styles.service.ts
+++ b/src/writing-styles/writing-styles.service.ts
@@ -6,6 +6,10 @@ import { EntityManager, EntityRepository } from '@mikro-orm/core';
 import { User } from '../users/entities/user.entity';
 import { WritingStyleExample } from './entities/writing-style-example.entity';
 import axios from 'axios';
+import {
+  UserIdentifierLike,
+  buildUserFilterFromInput,
+} from '../users/utils/user-identifier.util';
 import TurndownService = require('turndown');
 
 @Injectable()
@@ -26,13 +30,15 @@ export class WritingStylesService {
 
   async create(
     createWritingStyleDto: CreateWritingStyleDto,
-    userId: number,
+    userId: UserIdentifierLike,
   ): Promise<WritingStyle> {
     const { name, examples: scrapedExamples } = createWritingStyleDto;
 
     const writingStyle = new WritingStyle();
     writingStyle.name = name;
-    const user = await this.userRepository.findOne({ userId });
+    const user = await this.userRepository.findOne(
+      buildUserFilterFromInput(userId),
+    );
     if (!user) {
       throw new Error('User not found');
     }
@@ -59,16 +65,20 @@ export class WritingStylesService {
     return writingStyle;
   }
 
-  async findAll(userId: number) {
-    const user = await this.userRepository.findOne({ userId });
+  async findAll(userId: UserIdentifierLike) {
+    const user = await this.userRepository.findOne(
+      buildUserFilterFromInput(userId),
+    );
     if (!user) {
       throw new Error('User not found');
     }
     return this.writingStyleRepository.find({ user: user });
   }
 
-  async findOne(id: number, userId: number) {
-    const user = await this.userRepository.findOne({ userId });
+  async findOne(id: number, userId: UserIdentifierLike) {
+    const user = await this.userRepository.findOne(
+      buildUserFilterFromInput(userId),
+    );
     if (!user) {
       throw new Error('User not found');
     }
@@ -79,8 +89,10 @@ export class WritingStylesService {
     return style;
   }
 
-  async remove(id: number, userId: number) {
-    const user = await this.userRepository.findOne({ userId });
+  async remove(id: number, userId: UserIdentifierLike) {
+    const user = await this.userRepository.findOne(
+      buildUserFilterFromInput(userId),
+    );
     if (!user) {
       throw new Error('User not found');
     }


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-427](https://linear.app/chill-mato/issue/CHI-427)

## 변경사항 요약

User 엔티티의 Primary Key를 serial integer에서 UUID로 마이그레이션하여 보안성과 확장성을 개선

### 주요 변경사항

#### 1. User Entity 변경
- PK 타입: `number` → `string (UUID)`
- UUID v4 자동 생성 로직 추가
- 관련 entity relationships 업데이트

#### 2. 서비스 레이어 전면 업데이트 (33개 파일)
- **Controllers**: userId 파라미터 타입 변경 (number → string)
- ArticlesController, ScrapsController, FoldersController, LibraryItemsController 등
- **Services**: 비즈니스 로직에서 UUID 처리
- ArticlesService, ScrapsService, TagsService, FoldersService 등
- **DTOs**: userId 필드 타입 변경 및 validation 추가
- GenerateArticleDto, FileAnalysisDto 등

#### 3. 유틸리티 및 파이프 추가
- **UserIdPipe**: UUID format validation 및 변환 파이프
- **UserIdentifierUtil**: UUID/email 자동 구분 및 변환 유틸리티
- `identifyUserIdType()`: UUID vs email 자동 판별
- `convertToUserId()`: email → UUID 변환 헬퍼

#### 4. 인증 시스템 업데이트
- JWT Strategy에서 UUID 처리 로직 추가
- AuthService에서 UUID 기반 사용자 조회

#### 5. 관련 엔티티 업데이트
- JobStatus entity의 userId 타입 변경
- 모든 user foreign key references를 UUID로 변경

### 기술적 이점
1. **보안성**: 사용자 ID 예측 불가능 (sequential integer 취약점 해소)
2. **확장성**: 분산 시스템에서 ID 충돌 없이 고유성 보장
3. **마이그레이션**: 향후 다른 DB로 이전 시 ID 충돌 최소화

## 데이터베이스 변경사항

### Schema 변경
- `users.id`: `SERIAL` → `UUID` (기본값: `gen_random_uuid()`)
- 모든 user foreign key 컬럼: `INTEGER` → `UUID`

### Migration 필요
- [x] 기존 데이터 마이그레이션 스크립트 실행 필요
- [x] 운영 DB 적용 전 staging 환경 테스트 필수

## 📦 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음