### PR TITLE
[CHI-429] Articles/ArticleArchive UUID 마이그레이션 및 하위호환성 구현

### DIFF
--- a/src/api/admin/admin.controller.ts
+++ b/src/api/admin/admin.controller.ts
@@ -29,7 +29,7 @@ export type AdminUserDetailResponse = {
     createdAt: string;
   }[];
   articles: {
-    articleId: number;
+    articleId: string;
     topic: string;
     keyInsight: string;
     generationStatus: 'processing' | 'completed' | 'failed';
@@ -41,7 +41,7 @@ export type AdminArticleGenerationResultsResponse = {
   userId: string;
   email: string;
   name: string;
-  articleId: number;
+  articleId: string;
   topic: string;
   keyInsight: string;
   scrapIds: string[];
@@ -64,7 +64,7 @@ export type AdminArticleDetailResponse = {
   userId: string;
   email: string;
   name: string;
-  articleId: number;
+  articleId: string;
   topic: string;
   keyInsight: string;
   generationParams: Record<string, unknown> | null;
@@ -79,7 +79,7 @@ export type AdminArticleDetailResponse = {
     createdAt: string;
   }[];
   archives: {
-    articleArchiveId: number;
+    articleArchiveId: string;
     versionNumber: number | null;
     title: string;
     content: string;
@@ -369,7 +369,7 @@ export class AdminController {
   @Get('articles/detail')
   async getArticleDetail(
     @Query('userId', UserIdParamPipe) userId: string,
-    @Query('articleId') articleId: number,
+    @Query('articleId') articleId: string,
   ): Promise<AdminArticleDetailResponse> {
     return this.adminService.getArticleDetail(userId, articleId);
   }

--- a/src/api/admin/admin.service.ts
+++ b/src/api/admin/admin.service.ts
@@ -203,7 +203,7 @@ export class AdminService {
   /**
    * 특정 아티클 생성 요청의 상세 결과
    */
-  async getArticleDetail(userId: UserIdentifierLike, articleId: number) {
+  async getArticleDetail(userId: UserIdentifierLike, articleId: string) {
     const article = await this.em.findOne(
       Article,
       {

--- a/src/api/article-archive/article-archive.controller.ts
+++ b/src/api/article-archive/article-archive.controller.ts
@@ -11,6 +11,7 @@ import {
 import { ArticleArchiveService } from '../../article-archive/article-archive.service';
 import { CreateArticleArchiveDto } from './dto/create-article-archive.dto';
 import { UpdateArticleArchiveDto } from './dto/update-article-archive.dto';
+import { ArticleArchiveIdParamPipe } from '../../article-archive/pipes/article-archive-id.pipe';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 
 @UseGuards(JwtAuthGuard)
@@ -29,20 +30,20 @@ export class ArticleArchiveController {
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
+  findOne(@Param('id', ArticleArchiveIdParamPipe) id: string) {
     return this.articleArchiveService.findOne(id);
   }
 
   @Patch(':id')
   update(
-    @Param('id') id: string,
+    @Param('id', ArticleArchiveIdParamPipe) id: string,
     @Body() updateArticleArchiveDto: UpdateArticleArchiveDto,
   ) {
     return this.articleArchiveService.update(id, updateArticleArchiveDto);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
+  remove(@Param('id', ArticleArchiveIdParamPipe) id: string) {
     return this.articleArchiveService.remove(id);
   }
 }

--- a/src/api/article-archive/article-archive.controller.ts
+++ b/src/api/article-archive/article-archive.controller.ts
@@ -30,7 +30,7 @@ export class ArticleArchiveController {
 
   @Get(':id')
   findOne(@Param('id') id: string) {
-    return this.articleArchiveService.findOne(+id);
+    return this.articleArchiveService.findOne(id);
   }
 
   @Patch(':id')
@@ -38,11 +38,11 @@ export class ArticleArchiveController {
     @Param('id') id: string,
     @Body() updateArticleArchiveDto: UpdateArticleArchiveDto,
   ) {
-    return this.articleArchiveService.update(+id, updateArticleArchiveDto);
+    return this.articleArchiveService.update(id, updateArticleArchiveDto);
   }
 
   @Delete(':id')
   remove(@Param('id') id: string) {
-    return this.articleArchiveService.remove(+id);
+    return this.articleArchiveService.remove(id);
   }
 }

--- a/src/api/articles/articles.controller.ts
+++ b/src/api/articles/articles.controller.ts
@@ -16,6 +16,7 @@ import {
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { ArticlesService } from '../../articles/articles.service';
+import { ArticleIdParamPipe } from '../../articles/pipes/article-id.pipe';
 import { CreateArticleDto } from './dto/create-article.dto';
 import {
   GenerateArticleDto,
@@ -104,8 +105,8 @@ export class ArticlesController {
    */
   @Version('1')
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.articlesService.findOne(+id);
+  findOne(@Param('id', ArticleIdParamPipe) id: string) {
+    return this.articlesService.findOne(id);
   }
 
   /**
@@ -125,8 +126,8 @@ export class ArticlesController {
    */
   @Version('1')
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateArticleDto: UpdateArticleDto) {
-    return this.articlesService.update(+id, updateArticleDto);
+  update(@Param('id', ArticleIdParamPipe) id: string, @Body() updateArticleDto: UpdateArticleDto) {
+    return this.articlesService.update(id, updateArticleDto);
   }
 
   /**
@@ -135,8 +136,8 @@ export class ArticlesController {
    */
   @Version('1')
   @Delete(':id')
-  async remove(@Param('id') id: string) {
-    await this.articlesService.remove(+id);
+  async remove(@Param('id', ArticleIdParamPipe) id: string) {
+    await this.articlesService.remove(id);
     return { message: 'Article removed successfully' };
   }
 
@@ -146,8 +147,8 @@ export class ArticlesController {
    */
   @Version('1')
   @Post(':id/archive')
-  archive(@Param('id') id: string) {
-    return this.articlesService.archive(+id);
+  archive(@Param('id', ArticleIdParamPipe) id: string) {
+    return this.articlesService.archive(id);
   }
 
   /**
@@ -161,7 +162,7 @@ export class ArticlesController {
   @ApiResponse({ status: 400, description: '잘못된 요청입니다' })
   @ApiResponse({ status: 403, description: '권한이 없습니다' })
   @ApiResponse({ status: 404, description: '아티클을 찾을 수 없습니다' })
-  getVersions(@Request() req: any, @Param('id', ParseIntPipe) id: number) {
+  getVersions(@Request() req: any, @Param('id', ArticleIdParamPipe) id: string) {
     const userId = req.user.id;
     return this.articlesService.getVersions(id, userId);
   }
@@ -182,7 +183,7 @@ export class ArticlesController {
   })
   restoreVersion(
     @Request() req: any,
-    @Param('id', ParseIntPipe) id: number,
+    @Param('id', ArticleIdParamPipe) id: string,
     @Param('versionNumber', ParseIntPipe) versionNumber: number,
   ) {
     const userId = req.user.id;
@@ -195,7 +196,7 @@ export class ArticlesController {
    */
   @Version('1')
   @Delete('batch')
-  removeBatch(@Body() ids: number[]) {
+  removeBatch(@Body() ids: string[]) {
     return this.articlesService.removeBatch(ids);
   }
 
@@ -248,9 +249,9 @@ export class ArticlesController {
   @Version('2')
   @Get(':id/status')
   async getArticleStatusV2(
-    @Param('id') id: string,
+    @Param('id', ArticleIdParamPipe) id: string,
   ): Promise<ArticleStatusV2Response> {
-    return this.articlesService.getArticleStatusV2(+id);
+    return this.articlesService.getArticleStatusV2(id);
   }
 
   /**
@@ -316,9 +317,9 @@ export class ArticlesController {
   @Version('3')
   @Get(':id/status')
   async getArticleStatusV3(
-    @Param('id') id: string,
+    @Param('id', ArticleIdParamPipe) id: string,
   ): Promise<ArticleStatusV2Response> {
-    return this.articlesService.getArticleStatusV3(+id);
+    return this.articlesService.getArticleStatusV3(id);
   }
 
   /**
@@ -388,7 +389,7 @@ export class ArticlesController {
   @Post(':id/regenerate')
   async regenerateArticleV3(
     @Request() req: any,
-    @Param('id', ParseIntPipe) id: number,
+    @Param('id', ArticleIdParamPipe) id: string,
     @Body() regenerateDto: RegenerateArticleV3Dto,
   ) {
     const userId = req.user.id;
@@ -415,7 +416,7 @@ export class ArticlesController {
   @Sse()
   regenerateArticleV3Stream(
     @Request() req: any,
-    @Param('id', ParseIntPipe) id: number,
+    @Param('id', ArticleIdParamPipe) id: string,
     @Body() regenerateDto: RegenerateArticleV3Dto,
   ): Observable<MessageEvent> {
     const userId = req.user.id;

--- a/src/api/articles/dto/generate-article-v2.dto.ts
+++ b/src/api/articles/dto/generate-article-v2.dto.ts
@@ -62,9 +62,12 @@ export interface TemplateSectionV2Dto {
  * V2 API 비동기 생성 응답 - 즉시 202 반환
  */
 export class GenerateArticleV2Response {
-  @ApiProperty()
-  @IsNumber()
-  articleId: number;
+  @ApiProperty({
+    description: 'Article ID (UUID)',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsString()
+  articleId: string;
 
   @ApiProperty()
   @IsString()
@@ -83,9 +86,12 @@ export class GenerateArticleV2Response {
  * V2 API 상태 확인 응답
  */
 export class ArticleStatusV2Response {
-  @ApiProperty()
-  @IsNumber()
-  articleId: number;
+  @ApiProperty({
+    description: 'Article ID (UUID)',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsString()
+  articleId: string;
 
   @ApiProperty()
   @IsString()

--- a/src/api/articles/dto/generate-article.dto.ts
+++ b/src/api/articles/dto/generate-article.dto.ts
@@ -60,8 +60,8 @@ export interface TemplateSectionDto {
 
 export class GenerateArticleResponse {
   @ApiProperty()
-  @IsNumber()
-  id: number;
+  @IsString()
+  id: string;
 
   @ApiProperty()
   @IsString()

--- a/src/api/folders/dto/move-folder-items.dto.ts
+++ b/src/api/folders/dto/move-folder-items.dto.ts
@@ -16,14 +16,17 @@ export class MoveFolderItemsDto {
   scrapIds?: string[];
 
   @ApiProperty({
-    description: 'Array of article IDs to move to this folder',
+    description: 'Array of article IDs to move to this folder (UUIDs or legacy integers)',
     required: false,
-    example: [10, 20, 30],
+    example: [
+      '550e8400-e29b-41d4-a716-446655440000',
+      '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+    ],
   })
   @IsOptional()
   @IsArray()
-  @IsInt({ each: true })
-  articleIds?: number[];
+  @IsString({ each: true })
+  articleIds?: string[];
 
   @ApiProperty({
     description: 'Target folder UUID (null to remove from folder)',

--- a/src/api/scraps/dto/create-scrap.dto.ts
+++ b/src/api/scraps/dto/create-scrap.dto.ts
@@ -99,10 +99,14 @@ export class CreateScrapDto {
   @IsString()
   userComment?: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Associated article ID (UUID or legacy integer)',
+    required: false,
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   @IsOptional()
-  @IsNumber()
-  articleId?: number;
+  @IsString()
+  articleId?: string;
 
   @ApiProperty()
   @IsOptional()

--- a/src/api/scraps/dto/scrap-response.dto.ts
+++ b/src/api/scraps/dto/scrap-response.dto.ts
@@ -103,11 +103,11 @@ export class ScrapResponseDto {
   updatedAt: Date;
 
   @ApiProperty({
-    description: 'Associated article ID',
+    description: 'Associated article ID (UUID or legacy integer)',
     required: false,
-    example: 1,
+    example: '550e8400-e29b-41d4-a716-446655440000',
   })
-  articleId?: number;
+  articleId?: string;
 
   @ApiProperty({
     description: 'Tags associated with the scrap',
@@ -280,11 +280,11 @@ export class ScrapSummaryDto {
   updatedAt: Date;
 
   @ApiProperty({
-    description: 'Associated article ID',
+    description: 'Associated article ID (UUID or legacy integer)',
     required: false,
-    example: 1,
+    example: '550e8400-e29b-41d4-a716-446655440000',
   })
-  articleId?: number;
+  articleId?: string;
 
   @ApiProperty({
     description: 'Tags associated with the scrap',

--- a/src/api/scraps/scraps.controller.ts
+++ b/src/api/scraps/scraps.controller.ts
@@ -62,7 +62,7 @@ export class ScrapsController {
   @Get()
   async findAll(
     @Request() req: any,
-    @Query('articleId') articleId?: number,
+    @Query('articleId') articleId?: string,
     @Query('search') search?: string,
     @Query('page') page?: number,
     @Query('limit') limit?: number,
@@ -235,7 +235,7 @@ export class ScrapsController {
    */
   @Version('1')
   @Get('article/:articleId')
-  async findByArticle(@Param('articleId', ParseIntPipe) articleId: number) {
+  async findByArticle(@Param('articleId') articleId: string) {
     try {
       return await this.scrapsService.findByArticle(articleId);
     } catch (error: any) {
@@ -380,7 +380,7 @@ export class ScrapsController {
   @Get()
   async findAllV2(
     @Request() req: any,
-    @Query('articleId') articleId?: number,
+    @Query('articleId') articleId?: string,
     @Query('search') search?: string,
     @Query('page') page?: number,
     @Query('limit') limit?: number,

--- a/src/article-archive/article-archive.service.ts
+++ b/src/article-archive/article-archive.service.ts
@@ -5,6 +5,12 @@ import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 import { ArticleArchive } from './entities/article-archive.entity';
 import { Article } from '../articles/entities/article.entity';
 import { InjectRepository } from '@mikro-orm/nestjs';
+import {
+  ArticleArchiveIdentifierLike,
+  ensureArticleArchiveIdentifier,
+  buildArticleArchiveFilterFromInput,
+  isUuid,
+} from './utils/article-archive-identifier.util';
 
 @Injectable()
 export class ArticleArchiveService {
@@ -15,6 +21,38 @@ export class ArticleArchiveService {
     @InjectRepository(Article)
     private readonly articleRepository: EntityRepository<Article>,
   ) {}
+
+  /**
+   * Resolve article archive identifier (UUID or legacy numeric ID) to canonical UUID
+   * @param identifier Article archive UUID or legacy numeric ID
+   * @param options Configuration options
+   * @returns Canonical UUID string or null if not found
+   */
+  async resolveCanonicalArticleArchiveId(
+    identifier: ArticleArchiveIdentifierLike,
+    { throwOnNotFound = true }: { throwOnNotFound?: boolean } = {},
+  ): Promise<string | null> {
+    const normalized = ensureArticleArchiveIdentifier(identifier);
+
+    // If it's already a UUID, return it
+    if (typeof normalized === 'string' && isUuid(normalized)) {
+      return normalized.toLowerCase();
+    }
+
+    // Look up by legacy ID
+    const articleArchive = await this.articleArchiveRepository.findOne(
+      buildArticleArchiveFilterFromInput(normalized),
+    );
+
+    if (!articleArchive) {
+      if (throwOnNotFound) {
+        throw new NotFoundException('Article archive not found');
+      }
+      return null;
+    }
+
+    return articleArchive.articleArchiveId;
+  }
 
   async create(createArticleArchiveDto: CreateArticleArchiveDto) {
     const articleArchive = new ArticleArchive();

--- a/src/article-archive/article-archive.service.ts
+++ b/src/article-archive/article-archive.service.ts
@@ -27,7 +27,7 @@ export class ArticleArchiveService {
    * 특정 아티클의 새로운 버전을 생성합니다
    */
   async createVersion(
-    articleId: number,
+    articleId: string,
     title: string,
     content: string,
   ): Promise<ArticleArchive> {
@@ -64,7 +64,7 @@ export class ArticleArchiveService {
   /**
    * 특정 아티클의 모든 버전을 조회합니다
    */
-  async findVersionsByArticle(articleId: number): Promise<ArticleArchive[]> {
+  async findVersionsByArticle(articleId: string): Promise<ArticleArchive[]> {
     const article = await this.articleRepository.findOne({ articleId });
     if (!article) {
       throw new NotFoundException('아티클을 찾을 수 없습니다');
@@ -80,7 +80,7 @@ export class ArticleArchiveService {
    * 특정 버전의 아카이브를 조회합니다
    */
   async findSpecificVersion(
-    articleId: number,
+    articleId: string,
     versionNumber: number,
   ): Promise<ArticleArchive | null> {
     const article = await this.articleRepository.findOne({ articleId });
@@ -98,7 +98,7 @@ export class ArticleArchiveService {
   /**
    * 최신 버전을 조회합니다
    */
-  async findLatestVersion(articleId: number): Promise<ArticleArchive | null> {
+  async findLatestVersion(articleId: string): Promise<ArticleArchive | null> {
     const article = await this.articleRepository.findOne({ articleId });
     if (!article) {
       throw new NotFoundException('아티클을 찾을 수 없습니다');
@@ -114,7 +114,7 @@ export class ArticleArchiveService {
    * 버전 간 비교를 위한 데이터를 반환합니다
    */
   async compareVersions(
-    articleId: number,
+    articleId: string,
     version1: number,
     version2: number,
   ): Promise<{
@@ -140,7 +140,7 @@ export class ArticleArchiveService {
     return articleArchives;
   }
 
-  async findOne(id: number) {
+  async findOne(id: string) {
     const articleArchive = await this.articleArchiveRepository.findOne(
       { articleArchiveId: id },
       { populate: ['article'], filters: { isDeleted: false } },
@@ -151,7 +151,7 @@ export class ArticleArchiveService {
     return articleArchive;
   }
 
-  async update(id: number, updateArticleArchiveDto: UpdateArticleArchiveDto) {
+  async update(id: string, updateArticleArchiveDto: UpdateArticleArchiveDto) {
     const articleArchive = await this.articleArchiveRepository.findOne({
       articleArchiveId: id,
       isDeleted: false,
@@ -164,7 +164,7 @@ export class ArticleArchiveService {
     return articleArchive;
   }
 
-  async remove(id: number) {
+  async remove(id: string) {
     const articleArchive = await this.articleArchiveRepository.findOne({
       articleArchiveId: id,
       isDeleted: false,

--- a/src/article-archive/entities/article-archive.entity.ts
+++ b/src/article-archive/entities/article-archive.entity.ts
@@ -3,8 +3,16 @@ import { Article } from '../../articles/entities/article.entity';
 
 @Entity({ tableName: 'article_archive' })
 export class ArticleArchive {
-  @PrimaryKey({ fieldName: 'article_archive_id' })
-  articleArchiveId!: number;
+  @PrimaryKey({ fieldName: 'article_archive_id', type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
+  articleArchiveId!: string;
+
+  @Property({
+    fieldName: 'legacy_article_archive_id',
+    type: 'integer',
+    nullable: true,
+    unique: true,
+  })
+  legacyArticleArchiveId?: number;
 
   @Property({ fieldName: 'title', type: 'varchar', length: 500 })
   title!: string;

--- a/src/article-archive/pipes/article-archive-id.pipe.ts
+++ b/src/article-archive/pipes/article-archive-id.pipe.ts
@@ -1,0 +1,36 @@
+import {
+  BadRequestException,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
+import { ArticleArchiveService } from '../article-archive.service';
+
+/**
+ * Pipe to validate and normalize article archive identifiers (UUID or legacy numeric ID)
+ * This pipe converts incoming article archive IDs to their canonical UUID form
+ */
+@Injectable()
+export class ArticleArchiveIdParamPipe implements PipeTransform {
+  constructor(
+    private readonly articleArchiveService: ArticleArchiveService,
+  ) {}
+
+  async transform(
+    value: string | number | undefined,
+  ): Promise<string | undefined> {
+    if (value === null || value === undefined || `${value}`.trim() === '') {
+      return undefined;
+    }
+
+    const canonical =
+      await this.articleArchiveService.resolveCanonicalArticleArchiveId(value, {
+        throwOnNotFound: false,
+      });
+
+    if (!canonical) {
+      throw new BadRequestException('Invalid article archive identifier');
+    }
+
+    return canonical;
+  }
+}

--- a/src/article-archive/utils/article-archive-identifier.util.ts
+++ b/src/article-archive/utils/article-archive-identifier.util.ts
@@ -1,0 +1,78 @@
+import { FilterQuery } from '@mikro-orm/core';
+import { ArticleArchive } from '../entities/article-archive.entity';
+
+export type ArticleArchiveIdentifier = string | number;
+export type ArticleArchiveIdentifierLike =
+  | ArticleArchiveIdentifier
+  | null
+  | undefined;
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isUuid(value: string): boolean {
+  return UUID_REGEX.test(value.trim());
+}
+
+export function normalizeArticleArchiveIdentifier(
+  value: ArticleArchiveIdentifierLike,
+): ArticleArchiveIdentifier | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (isUuid(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+
+  const parsed = Number(trimmed);
+  if (!Number.isNaN(parsed)) {
+    return parsed;
+  }
+
+  throw new Error(`Invalid article archive identifier: ${value}`);
+}
+
+export function ensureArticleArchiveIdentifier(
+  value: ArticleArchiveIdentifierLike,
+): ArticleArchiveIdentifier {
+  const normalized = normalizeArticleArchiveIdentifier(value);
+  if (normalized === undefined) {
+    throw new Error('Article archive identifier is required');
+  }
+  return normalized;
+}
+
+export function buildArticleArchiveFilterFromInput(
+  value: ArticleArchiveIdentifierLike,
+): FilterQuery<ArticleArchive> {
+  return buildArticleArchiveWhere(ensureArticleArchiveIdentifier(value));
+}
+
+export function buildArticleArchiveWhere(
+  identifier: ArticleArchiveIdentifier,
+): FilterQuery<ArticleArchive> {
+  if (typeof identifier === 'string') {
+    if (!isUuid(identifier)) {
+      throw new Error(`Invalid UUID string: ${identifier}`);
+    }
+    return { articleArchiveId: identifier.toLowerCase() };
+  }
+
+  if (!Number.isInteger(identifier)) {
+    throw new Error(
+      `Legacy article archive ID must be an integer: ${identifier}`,
+    );
+  }
+
+  return { legacyArticleArchiveId: identifier };
+}

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -35,11 +35,6 @@ import { Observable } from 'rxjs';
 import { MessageEvent } from '@nestjs/common';
 import { EventType } from '../ai-workflows/models/streaming';
 import { RegenerateArticleOutput } from '../ai-workflows/dto/regenerate.dto';
-import {
-  ScrapIdentifier,
-  isUuid,
-} from '../scraps/utils/scrap-identifier.util';
-import { FilterQuery } from '@mikro-orm/core';
 // Analytics tracking migrated to extension client (PostHog).
 
 @Injectable()
@@ -308,7 +303,7 @@ export class ArticlesService {
   /**
    * 특정 아티클 조회
    */
-  async findOne(articleId: number): Promise<any> {
+  async findOne(articleId: string): Promise<any> {
     const article = await this.articleRepository.findOne(
       { articleId },
       {
@@ -415,7 +410,7 @@ export class ArticlesService {
    * 아티클 업데이트
    */
   async update(
-    articleId: number,
+    articleId: string,
     updateArticleDto: UpdateArticleDto,
   ): Promise<any> {
     const article = await this.articleRepository.findOne(
@@ -497,7 +492,7 @@ export class ArticlesService {
   /**
    * 아티클 삭제
    */
-  async remove(articleId: number): Promise<void> {
+  async remove(articleId: string): Promise<void> {
     const article = await this.articleRepository.findOne(
       { articleId, isDeleted: false },
       {
@@ -523,7 +518,7 @@ export class ArticlesService {
   /**
    * 아티클 아카이브
    */
-  async archive(articleId: number): Promise<ArticleArchive> {
+  async archive(articleId: string): Promise<ArticleArchive> {
     const article = await this.findOne(articleId);
 
     // 최신 아카이브에서 title과 content 가져오기
@@ -547,7 +542,7 @@ export class ArticlesService {
   /**
    * 아티클 버전 히스토리 조회
    */
-  async getVersions(articleId: number, userId: string): Promise<any[]> {
+  async getVersions(articleId: string, userId: string): Promise<any[]> {
     this.logger.log(
       `📋 Fetching versions for article ${articleId} by user ${userId}`,
     );
@@ -591,7 +586,7 @@ export class ArticlesService {
    * 특정 버전으로 복원
    */
   async restoreVersion(
-    articleId: number,
+    articleId: string,
     versionNumber: number,
     userId: string,
   ): Promise<any> {
@@ -702,7 +697,7 @@ export class ArticlesService {
   /**
    * 배치 아티클 삭제
    */
-  async removeBatch(articleIds: number[]): Promise<void> {
+  async removeBatch(articleIds: string[]): Promise<void> {
     const articles = await this.articleRepository.find({
       articleId: { $in: articleIds },
       isDeleted: false,
@@ -770,7 +765,7 @@ export class ArticlesService {
    * V2 API: 아티클 상태 확인
    */
   async getArticleStatusV2(
-    articleId: number,
+    articleId: string,
   ): Promise<ArticleStatusV2Response> {
     const article = await this.articleRepository.findOne(
       { articleId, isDeleted: false },
@@ -829,7 +824,7 @@ export class ArticlesService {
    * 백그라운드에서 실제 아티클 생성 수행
    */
   private async performBackgroundGeneration(
-    articleId: number,
+    articleId: string,
     generateDto: GenerateArticleV2Dto,
   ): Promise<void> {
     try {
@@ -1044,7 +1039,7 @@ export class ArticlesService {
    * V2 API: 아티클 상태 확인 (PDF 진행률 포함)
    */
   async getArticleStatusV3(
-    articleId: number,
+    articleId: string,
   ): Promise<ArticleStatusV2Response> {
     const article = await this.articleRepository.findOne(
       { articleId, isDeleted: false },
@@ -1107,7 +1102,7 @@ export class ArticlesService {
    * V3 백그라운드에서 실제 아티클 생성 수행 (PDF 지원)
    */
   private async performBackgroundGenerationV3(
-    articleId: number,
+    articleId: string,
     generateDto: GenerateArticleV3Dto,
   ): Promise<void> {
     try {
@@ -1612,7 +1607,7 @@ export class ArticlesService {
    * V3: 기존 아티클 재생성 (동기)
    */
   async regenerateArticleV3(
-    articleId: number,
+    articleId: string,
     userId: string,
     dto: RegenerateArticleV3Dto,
   ): Promise<any> {
@@ -2007,7 +2002,7 @@ export class ArticlesService {
    * V3: 기존 아티클 재생성 (스트리밍)
    */
   regenerateArticleV3Stream(
-    articleId: number,
+    articleId: string,
     userId: string,
     dto: RegenerateArticleV3Dto,
   ): Observable<MessageEvent> {
@@ -2515,44 +2510,6 @@ export class ArticlesService {
         }
       })();
     });
-  }
-
-  /**
-   * Build a filter query for scrap IDs, handling both UUID and legacy integer IDs
-   * @param scrapIds Array of scrap identifiers (UUIDs or legacy integers)
-   * @returns FilterQuery for scraps that handles both ID types
-   */
-  private buildScrapIdFilter(
-    scrapIds: ScrapIdentifier[],
-  ): FilterQuery<Scrap> {
-    if (!scrapIds || scrapIds.length === 0) {
-      return { scrapId: { $in: [] } };
-    }
-
-    // Separate UUIDs and legacy IDs
-    const uuids = scrapIds.filter(
-      (id) => typeof id === 'string' && isUuid(id),
-    );
-    const legacyIds = scrapIds.filter((id) => typeof id === 'number');
-
-    // Build OR condition for both UUID and legacy IDs
-    const idConditions: any[] = [];
-    if (uuids.length > 0) {
-      idConditions.push({ scrapId: { $in: uuids } });
-    }
-    if (legacyIds.length > 0) {
-      idConditions.push({ legacyScrapId: { $in: legacyIds } });
-    }
-
-    if (idConditions.length === 0) {
-      return { scrapId: { $in: [] } };
-    }
-
-    if (idConditions.length === 1) {
-      return idConditions[0];
-    }
-
-    return { $or: idConditions } as FilterQuery<Scrap>;
   }
 
   private async getUserOrThrow(userId: string): Promise<User> {

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -35,6 +35,17 @@ import { Observable } from 'rxjs';
 import { MessageEvent } from '@nestjs/common';
 import { EventType } from '../ai-workflows/models/streaming';
 import { RegenerateArticleOutput } from '../ai-workflows/dto/regenerate.dto';
+import {
+  ArticleIdentifierLike,
+  ensureArticleIdentifier,
+  buildArticleFilterFromInput,
+  isUuid,
+} from './utils/article-identifier.util';
+import {
+  ScrapIdentifier,
+  isUuid as isScrapUuid,
+} from '../scraps/utils/scrap-identifier.util';
+import { FilterQuery } from '@mikro-orm/core';
 // Analytics tracking migrated to extension client (PostHog).
 
 @Injectable()
@@ -298,6 +309,38 @@ export class ArticlesService {
       orderBy: { createdAt: 'DESC' },
       filters: { isDeleted: false },
     });
+  }
+
+  /**
+   * Resolve article identifier (UUID or legacy numeric ID) to canonical UUID
+   * @param identifier Article UUID or legacy numeric ID
+   * @param options Configuration options
+   * @returns Canonical UUID string or null if not found
+   */
+  async resolveCanonicalArticleId(
+    identifier: ArticleIdentifierLike,
+    { throwOnNotFound = true }: { throwOnNotFound?: boolean } = {},
+  ): Promise<string | null> {
+    const normalized = ensureArticleIdentifier(identifier);
+
+    // If it's already a UUID, return it
+    if (typeof normalized === 'string' && isUuid(normalized)) {
+      return normalized.toLowerCase();
+    }
+
+    // Look up by legacy ID
+    const article = await this.articleRepository.findOne(
+      buildArticleFilterFromInput(normalized),
+    );
+
+    if (!article) {
+      if (throwOnNotFound) {
+        throw new NotFoundException('Article not found');
+      }
+      return null;
+    }
+
+    return article.articleId;
   }
 
   /**
@@ -2510,6 +2553,44 @@ export class ArticlesService {
         }
       })();
     });
+  }
+
+  /**
+   * Build a filter query for scrap IDs, handling both UUID and legacy integer IDs
+   * @param scrapIds Array of scrap identifiers (UUIDs or legacy integers)
+   * @returns FilterQuery for scraps that handles both ID types
+   */
+  private buildScrapIdFilter(
+    scrapIds: ScrapIdentifier[],
+  ): FilterQuery<Scrap> {
+    if (!scrapIds || scrapIds.length === 0) {
+      return { scrapId: { $in: [] } };
+    }
+
+    // Separate UUIDs and legacy IDs
+    const uuids = scrapIds.filter(
+      (id) => typeof id === 'string' && isScrapUuid(id),
+    );
+    const legacyIds = scrapIds.filter((id) => typeof id === 'number');
+
+    // Build OR condition for both UUID and legacy IDs
+    const idConditions: any[] = [];
+    if (uuids.length > 0) {
+      idConditions.push({ scrapId: { $in: uuids } });
+    }
+    if (legacyIds.length > 0) {
+      idConditions.push({ legacyScrapId: { $in: legacyIds } });
+    }
+
+    if (idConditions.length === 0) {
+      return { scrapId: { $in: [] } };
+    }
+
+    if (idConditions.length === 1) {
+      return idConditions[0];
+    }
+
+    return { $or: idConditions } as FilterQuery<Scrap>;
   }
 
   private async getUserOrThrow(userId: string): Promise<User> {

--- a/src/articles/entities/article.entity.ts
+++ b/src/articles/entities/article.entity.ts
@@ -16,8 +16,16 @@ import { WritingStyle } from '../../writing-styles/entities/writing-style.entity
 
 @Entity({ tableName: 'articles' })
 export class Article {
-  @PrimaryKey({ fieldName: 'article_id' })
-  articleId!: number;
+  @PrimaryKey({ fieldName: 'article_id', type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
+  articleId!: string;
+
+  @Property({
+    fieldName: 'legacy_article_id',
+    type: 'integer',
+    nullable: true,
+    unique: true,
+  })
+  legacyArticleId?: number;
 
   @Property({ fieldName: 'topic', type: 'varchar', length: 500 })
   topic!: string;

--- a/src/articles/pipes/article-id.pipe.ts
+++ b/src/articles/pipes/article-id.pipe.ts
@@ -1,0 +1,36 @@
+import {
+  BadRequestException,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
+import { ArticlesService } from '../articles.service';
+
+/**
+ * Pipe to validate and normalize article identifiers (UUID or legacy numeric ID)
+ * This pipe converts incoming article IDs to their canonical UUID form
+ */
+@Injectable()
+export class ArticleIdParamPipe implements PipeTransform {
+  constructor(private readonly articlesService: ArticlesService) {}
+
+  async transform(
+    value: string | number | undefined,
+  ): Promise<string | undefined> {
+    if (value === null || value === undefined || `${value}`.trim() === '') {
+      return undefined;
+    }
+
+    const canonical = await this.articlesService.resolveCanonicalArticleId(
+      value,
+      {
+        throwOnNotFound: false,
+      },
+    );
+
+    if (!canonical) {
+      throw new BadRequestException('Invalid article identifier');
+    }
+
+    return canonical;
+  }
+}

--- a/src/articles/utils/article-identifier.util.ts
+++ b/src/articles/utils/article-identifier.util.ts
@@ -1,0 +1,73 @@
+import { FilterQuery } from '@mikro-orm/core';
+import { Article } from '../entities/article.entity';
+
+export type ArticleIdentifier = string | number;
+export type ArticleIdentifierLike = ArticleIdentifier | null | undefined;
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isUuid(value: string): boolean {
+  return UUID_REGEX.test(value.trim());
+}
+
+export function normalizeArticleIdentifier(
+  value: ArticleIdentifierLike,
+): ArticleIdentifier | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (isUuid(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+
+  const parsed = Number(trimmed);
+  if (!Number.isNaN(parsed)) {
+    return parsed;
+  }
+
+  throw new Error(`Invalid article identifier: ${value}`);
+}
+
+export function ensureArticleIdentifier(
+  value: ArticleIdentifierLike,
+): ArticleIdentifier {
+  const normalized = normalizeArticleIdentifier(value);
+  if (normalized === undefined) {
+    throw new Error('Article identifier is required');
+  }
+  return normalized;
+}
+
+export function buildArticleFilterFromInput(
+  value: ArticleIdentifierLike,
+): FilterQuery<Article> {
+  return buildArticleWhere(ensureArticleIdentifier(value));
+}
+
+export function buildArticleWhere(
+  identifier: ArticleIdentifier,
+): FilterQuery<Article> {
+  if (typeof identifier === 'string') {
+    if (!isUuid(identifier)) {
+      throw new Error(`Invalid UUID string: ${identifier}`);
+    }
+    return { articleId: identifier.toLowerCase() };
+  }
+
+  if (!Number.isInteger(identifier)) {
+    throw new Error(`Legacy article ID must be an integer: ${identifier}`);
+  }
+
+  return { legacyArticleId: identifier };
+}

--- a/src/content/content.service.ts
+++ b/src/content/content.service.ts
@@ -493,7 +493,9 @@ export class ContentService {
     }
 
     return {
-      id: article.articleId.toString(),
+      // BACKWARD COMPATIBILITY: Use legacyArticleId for client parseInt() compatibility
+      // Chrome extension uses parseInt(item.id, 10) which requires numeric ID
+      id: article.legacyArticleId?.toString() || article.articleId.toString(),
       type: 'article',
       title: article.getLatestTitle() || 'Untitled',
       contentPreview,

--- a/src/folders/folders.service.ts
+++ b/src/folders/folders.service.ts
@@ -25,6 +25,7 @@ import {
   FolderResponseDto,
   FolderContentsDto,
 } from '../api/folders/dto/folder-response.dto';
+import { ArticleIdentifier } from '../articles/utils/article-identifier.util';
 
 @Injectable()
 export class FoldersService {
@@ -285,7 +286,7 @@ export class FoldersService {
     folderId: string | null,
     userId: UserIdentifierLike,
     scrapIds?: ScrapIdentifier[],
-    articleIds?: number[],
+    articleIds?: ArticleIdentifier[],
   ): Promise<{ movedScraps: number; movedArticles: number }> {
     return await this.em.transactional(async (em) => {
       let targetFolder: Folder | null = null;

--- a/src/folders/folders.service.ts
+++ b/src/folders/folders.service.ts
@@ -326,8 +326,11 @@ export class FoldersService {
 
       // Move articles
       if (articleIds && articleIds.length > 0) {
+        // Convert all identifiers to strings (UUIDs)
+        const articleIdStrings = articleIds.map((id) => String(id));
+
         const articles = await em.find(Article, {
-          articleId: { $in: articleIds },
+          articleId: { $in: articleIdStrings },
           user: userFilter as any,
           isDeleted: false,
         });

--- a/src/migrations/Migration20251110000000_articles_uuid_migration.sql
+++ b/src/migrations/Migration20251110000000_articles_uuid_migration.sql
@@ -1,0 +1,265 @@
+-- Migration: Articles and Article_Archive PK from Serial Integer to UUID
+-- Date: 2025-11-10
+-- Description: Migrates articles and article_archive tables to UUID while preserving legacy IDs
+
+-- ============================================================================
+-- FORWARD MIGRATION (UP)
+-- ============================================================================
+
+-- 1. Ensure UUID extension is enabled
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- ============================================================================
+-- PART 1: ARTICLES TABLE MIGRATION
+-- ============================================================================
+
+-- 2. Add new UUID column and legacy ID column to articles
+ALTER TABLE articles
+  ADD COLUMN article_uuid UUID DEFAULT uuid_generate_v4(),
+  ADD COLUMN legacy_article_id INTEGER;
+
+-- 3. Copy existing IDs to legacy column
+UPDATE articles SET legacy_article_id = article_id;
+
+-- 4. Drop existing foreign key constraints from referencing tables
+ALTER TABLE article_archive DROP CONSTRAINT IF EXISTS article_archive_article_id_foreign CASCADE;
+ALTER TABLE article_archive DROP CONSTRAINT IF EXISTS article_archive_article_id_fkey CASCADE;
+
+ALTER TABLE article_scraps DROP CONSTRAINT IF EXISTS article_scraps_article_id_foreign CASCADE;
+ALTER TABLE article_scraps DROP CONSTRAINT IF EXISTS article_scraps_article_id_fkey CASCADE;
+
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_article_id_foreign CASCADE;
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_article_id_fkey CASCADE;
+
+-- 5. Add UUID columns to referencing tables
+ALTER TABLE article_archive ADD COLUMN article_uuid UUID;
+ALTER TABLE article_scraps ADD COLUMN article_uuid UUID;
+ALTER TABLE tags ADD COLUMN article_uuid UUID;
+
+-- 6. Map UUIDs from articles to referencing tables via legacy IDs
+UPDATE article_archive aa
+SET article_uuid = a.article_uuid
+FROM articles a
+WHERE aa.article_id = a.article_id;
+
+UPDATE article_scraps as_
+SET article_uuid = a.article_uuid
+FROM articles a
+WHERE as_.article_id = a.article_id;
+
+UPDATE tags t
+SET article_uuid = a.article_uuid
+FROM articles a
+WHERE t.article_id = a.article_id
+  AND t.article_id IS NOT NULL;
+
+-- 7. Drop old primary key constraint from articles
+ALTER TABLE articles DROP CONSTRAINT articles_pkey CASCADE;
+
+-- 8. Drop old article_id column and rename UUID column
+ALTER TABLE articles DROP COLUMN article_id;
+ALTER TABLE articles RENAME COLUMN article_uuid TO article_id;
+
+-- 9. Add new primary key constraint with UUID
+ALTER TABLE articles ADD PRIMARY KEY (article_id);
+
+-- 10. Update referencing tables - rename UUID columns
+ALTER TABLE article_archive DROP COLUMN article_id;
+ALTER TABLE article_archive RENAME COLUMN article_uuid TO article_id;
+ALTER TABLE article_archive ALTER COLUMN article_id SET NOT NULL;
+
+ALTER TABLE article_scraps DROP COLUMN article_id;
+ALTER TABLE article_scraps RENAME COLUMN article_uuid TO article_id;
+ALTER TABLE article_scraps ALTER COLUMN article_id SET NOT NULL;
+
+ALTER TABLE tags DROP COLUMN article_id;
+ALTER TABLE tags RENAME COLUMN article_uuid TO article_id;
+-- tags.article_id remains nullable
+
+-- 11. Recreate foreign key constraints
+ALTER TABLE article_archive
+  ADD CONSTRAINT article_archive_article_id_fkey
+  FOREIGN KEY (article_id) REFERENCES articles(article_id) ON DELETE CASCADE;
+
+ALTER TABLE article_scraps
+  ADD CONSTRAINT article_scraps_article_id_fkey
+  FOREIGN KEY (article_id) REFERENCES articles(article_id) ON DELETE CASCADE;
+
+ALTER TABLE tags
+  ADD CONSTRAINT tags_article_id_fkey
+  FOREIGN KEY (article_id) REFERENCES articles(article_id) ON DELETE CASCADE;
+
+-- 12. Add unique constraint to legacy_article_id
+ALTER TABLE articles ADD CONSTRAINT articles_legacy_article_id_unique UNIQUE (legacy_article_id);
+
+-- 13. Create index on legacy_article_id for performance
+CREATE INDEX idx_articles_legacy_article_id ON articles(legacy_article_id);
+
+-- 14. Create sequence for legacy_article_id for new articles
+CREATE SEQUENCE IF NOT EXISTS articles_legacy_article_id_seq;
+
+-- 15. Set sequence to start after max existing legacy_article_id
+SELECT setval('articles_legacy_article_id_seq', COALESCE((SELECT MAX(legacy_article_id) FROM articles), 0));
+
+-- 16. Set default value for legacy_article_id to use sequence
+ALTER TABLE articles ALTER COLUMN legacy_article_id SET DEFAULT nextval('articles_legacy_article_id_seq');
+
+-- ============================================================================
+-- PART 2: ARTICLE_ARCHIVE TABLE MIGRATION
+-- ============================================================================
+
+-- 17. Add UUID column and legacy ID to article_archive
+ALTER TABLE article_archive
+  ADD COLUMN article_archive_uuid UUID DEFAULT uuid_generate_v4(),
+  ADD COLUMN legacy_article_archive_id INTEGER;
+
+-- 18. Copy existing archive IDs to legacy column
+UPDATE article_archive SET legacy_article_archive_id = article_archive_id;
+
+-- 19. Drop old PK and rename UUID column
+ALTER TABLE article_archive DROP CONSTRAINT article_archive_pkey CASCADE;
+ALTER TABLE article_archive DROP COLUMN article_archive_id;
+ALTER TABLE article_archive RENAME COLUMN article_archive_uuid TO article_archive_id;
+
+-- 20. Add new primary key
+ALTER TABLE article_archive ADD PRIMARY KEY (article_archive_id);
+
+-- 21. Add unique constraint and index for legacy archive ID
+ALTER TABLE article_archive ADD CONSTRAINT article_archive_legacy_id_unique UNIQUE (legacy_article_archive_id);
+CREATE INDEX idx_article_archive_legacy_id ON article_archive(legacy_article_archive_id);
+
+-- 22. Create sequence for legacy archive IDs
+CREATE SEQUENCE IF NOT EXISTS article_archive_legacy_id_seq;
+SELECT setval('article_archive_legacy_id_seq', COALESCE((SELECT MAX(legacy_article_archive_id) FROM article_archive), 0));
+ALTER TABLE article_archive ALTER COLUMN legacy_article_archive_id SET DEFAULT nextval('article_archive_legacy_id_seq');
+
+-- ============================================================================
+-- VERIFICATION
+-- ============================================================================
+
+-- Verify data integrity
+SELECT
+  'articles' as table_name,
+  COUNT(*) as total_rows,
+  COUNT(DISTINCT article_id) as unique_uuids,
+  COUNT(DISTINCT legacy_article_id) as unique_legacy_ids
+FROM articles
+UNION ALL
+SELECT
+  'article_archive',
+  COUNT(*),
+  COUNT(DISTINCT article_archive_id),
+  COUNT(DISTINCT legacy_article_archive_id)
+FROM article_archive;
+
+-- Check for orphaned relationships
+SELECT 'Orphaned article_archive' as issue, COUNT(*) as count
+FROM article_archive aa
+LEFT JOIN articles a ON a.article_id = aa.article_id
+WHERE a.article_id IS NULL
+UNION ALL
+SELECT 'Orphaned article_scraps', COUNT(*)
+FROM article_scraps as_
+LEFT JOIN articles a ON a.article_id = as_.article_id
+WHERE a.article_id IS NULL
+UNION ALL
+SELECT 'Orphaned tags with article_id', COUNT(*)
+FROM tags t
+LEFT JOIN articles a ON a.article_id = t.article_id
+WHERE t.article_id IS NOT NULL AND a.article_id IS NULL;
+
+-- ============================================================================
+-- ROLLBACK MIGRATION (DOWN)
+-- ============================================================================
+
+/*
+-- Uncomment to rollback
+
+-- 1. Drop foreign keys
+ALTER TABLE article_archive DROP CONSTRAINT IF EXISTS article_archive_article_id_fkey CASCADE;
+ALTER TABLE article_scraps DROP CONSTRAINT IF EXISTS article_scraps_article_id_fkey CASCADE;
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_article_id_fkey CASCADE;
+
+-- 2. Add temporary integer columns
+ALTER TABLE article_archive ADD COLUMN article_id_int INTEGER;
+ALTER TABLE article_scraps ADD COLUMN article_id_int INTEGER;
+ALTER TABLE tags ADD COLUMN article_id_int INTEGER;
+
+-- 3. Map legacy IDs back
+UPDATE article_archive aa
+SET article_id_int = a.legacy_article_id
+FROM articles a
+WHERE aa.article_id = a.article_id;
+
+UPDATE article_scraps as_
+SET article_id_int = a.legacy_article_id
+FROM articles a
+WHERE as_.article_id = a.article_id;
+
+UPDATE tags t
+SET article_id_int = a.legacy_article_id
+FROM articles a
+WHERE t.article_id = a.article_id
+  AND t.article_id IS NOT NULL;
+
+-- 4. Restore articles table
+ALTER TABLE articles DROP CONSTRAINT articles_pkey CASCADE;
+ALTER TABLE articles RENAME COLUMN article_id TO article_uuid;
+ALTER TABLE articles ADD COLUMN article_id INTEGER;
+UPDATE articles SET article_id = legacy_article_id;
+ALTER TABLE articles ALTER COLUMN article_id SET NOT NULL;
+ALTER TABLE articles ADD PRIMARY KEY (article_id);
+
+CREATE SEQUENCE IF NOT EXISTS articles_article_id_seq;
+SELECT setval('articles_article_id_seq', (SELECT MAX(article_id) FROM articles));
+ALTER TABLE articles ALTER COLUMN article_id SET DEFAULT nextval('articles_article_id_seq');
+
+-- 5. Restore article_archive table
+ALTER TABLE article_archive DROP CONSTRAINT article_archive_pkey CASCADE;
+ALTER TABLE article_archive RENAME COLUMN article_archive_id TO article_archive_uuid;
+ALTER TABLE article_archive ADD COLUMN article_archive_id INTEGER;
+UPDATE article_archive SET article_archive_id = legacy_article_archive_id;
+ALTER TABLE article_archive ALTER COLUMN article_archive_id SET NOT NULL;
+ALTER TABLE article_archive ADD PRIMARY KEY (article_archive_id);
+
+CREATE SEQUENCE IF NOT EXISTS article_archive_article_archive_id_seq;
+SELECT setval('article_archive_article_archive_id_seq', (SELECT MAX(article_archive_id) FROM article_archive));
+ALTER TABLE article_archive ALTER COLUMN article_archive_id SET DEFAULT nextval('article_archive_article_archive_id_seq');
+
+-- 6. Restore referencing table columns
+ALTER TABLE article_archive DROP COLUMN article_id;
+ALTER TABLE article_archive RENAME COLUMN article_id_int TO article_id;
+ALTER TABLE article_archive ALTER COLUMN article_id SET NOT NULL;
+
+ALTER TABLE article_scraps DROP COLUMN article_id;
+ALTER TABLE article_scraps RENAME COLUMN article_id_int TO article_id;
+ALTER TABLE article_scraps ALTER COLUMN article_id SET NOT NULL;
+
+ALTER TABLE tags DROP COLUMN article_id;
+ALTER TABLE tags RENAME COLUMN article_id_int TO article_id;
+
+-- 7. Recreate foreign keys
+ALTER TABLE article_archive
+  ADD CONSTRAINT article_archive_article_id_fkey
+  FOREIGN KEY (article_id) REFERENCES articles(article_id) ON DELETE CASCADE;
+
+ALTER TABLE article_scraps
+  ADD CONSTRAINT article_scraps_article_id_fkey
+  FOREIGN KEY (article_id) REFERENCES articles(article_id) ON DELETE CASCADE;
+
+ALTER TABLE tags
+  ADD CONSTRAINT tags_article_id_fkey
+  FOREIGN KEY (article_id) REFERENCES articles(article_id) ON DELETE CASCADE;
+
+-- 8. Cleanup
+DROP INDEX IF EXISTS idx_articles_legacy_article_id;
+DROP INDEX IF EXISTS idx_article_archive_legacy_id;
+ALTER TABLE articles DROP CONSTRAINT IF EXISTS articles_legacy_article_id_unique;
+ALTER TABLE article_archive DROP CONSTRAINT IF EXISTS article_archive_legacy_id_unique;
+ALTER TABLE articles DROP COLUMN legacy_article_id;
+ALTER TABLE articles DROP COLUMN article_uuid;
+ALTER TABLE article_archive DROP COLUMN legacy_article_archive_id;
+ALTER TABLE article_archive DROP COLUMN article_archive_uuid;
+DROP SEQUENCE IF EXISTS articles_legacy_article_id_seq;
+DROP SEQUENCE IF EXISTS article_archive_legacy_id_seq;
+*/

--- a/src/notifications/slack.service.ts
+++ b/src/notifications/slack.service.ts
@@ -141,7 +141,7 @@ export class SlackService {
    * Send article generation notification to Slack
    */
   async notifyArticleGeneration(articleData: {
-    articleId: number;
+    articleId: string;
     title: string;
     topic: string;
     keyInsight?: string;

--- a/src/scraps/scraps.service.ts
+++ b/src/scraps/scraps.service.ts
@@ -58,7 +58,7 @@ export class ScrapsService {
   async create(
     createScrapDto: CreateScrapDto,
     userId: UserIdentifierLike,
-    articleId?: number,
+    articleId?: string,
   ): Promise<ScrapSummaryDto> {
     const user = await this.userRepository.findOne(
       buildUserFilterFromInput(userId),
@@ -332,7 +332,7 @@ export class ScrapsService {
     };
   }
 
-  async findByArticle(articleId: number): Promise<Scrap[]> {
+  async findByArticle(articleId: string): Promise<Scrap[]> {
     // Find all ArticleScrap junction records for this article
     const articleScraps = await this.articleScrapRepository.find(
       { article: { articleId } },

--- a/src/slack-bot/dto/report-response.dto.ts
+++ b/src/slack-bot/dto/report-response.dto.ts
@@ -5,10 +5,10 @@ import { ApiProperty } from '@nestjs/swagger';
  */
 export class ReportResponseDto {
   @ApiProperty({
-    description: '생성된 아티클 ID',
-    example: 123,
+    description: '생성된 아티클 ID (UUID)',
+    example: '550e8400-e29b-41d4-a716-446655440000',
   })
-  articleId: number;
+  articleId: string;
 
   @ApiProperty({
     description: '보고서 내용 (Markdown)',

--- a/src/slack-bot/slack-bot.controller.ts
+++ b/src/slack-bot/slack-bot.controller.ts
@@ -132,12 +132,10 @@ export class SlackBotController {
     @Param('articleId') articleId: string,
   ): Promise<ReportResponseDto> {
     this.logger.log('Received report retrieval request', {
-      articleId: parseInt(articleId, 10),
+      articleId,
     });
 
-    const report = await this.slackBotService.getReport(
-      parseInt(articleId, 10),
-    );
+    const report = await this.slackBotService.getReport(articleId);
 
     if (!report) {
       throw new NotFoundException(`Report not found: ${articleId}`);

--- a/src/slack-bot/slack-bot.service.ts
+++ b/src/slack-bot/slack-bot.service.ts
@@ -126,7 +126,7 @@ export class SlackBotService {
   /**
    * 보고서 조회 (articleId로)
    */
-  async getReport(articleId: number): Promise<ReportResponseDto | null> {
+  async getReport(articleId: string): Promise<ReportResponseDto | null> {
     this.logger.log('Fetching report from database', { articleId });
 
     try {


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-429](https://linear.app/chill-mato/issue/CHI-429/)

## 📋 변경사항 요약

Articles와 ArticleArchive 테이블을 Serial Integer PK에서 UUID PK로 마이그레이션하면서 Chrome Extension의 완전한 하위호환성을 유지

### 주요 변경사항

**데이터베이스 마이그레이션**
- `article_id` → UUID PK
- `legacy_article_id` → Integer 컬럼 추가 (기존 ID 보존)
- `article_archive_id` → UUID PK
- `legacy_article_archive_id` → Integer 컬럼 추가
- PostgreSQL Sequence 생성으로 legacy ID 자동 할당

**엔티티 업데이트**
- Article Entity: UUID PK + nullable legacy ID
- ArticleArchive Entity: UUID PK + nullable legacy ID

**하위호환성 레이어**
- ContentService에서 Chrome Extension을 위해 `legacyArticleId` 반환
- 기존 Extension 코드 수정 없이 동작

**새로운 유틸리티 & Pipe**
- `src/articles/utils/article-identifier.util.ts` - UUID/숫자 ID 정규화 및 필터 생성
- `src/articles/pipes/article-id.pipe.ts` - 자동 ID 변환 파이프
- `src/article-archive/utils/article-archive-identifier.util.ts` - ArticleArchive용 유틸리티
- `src/article-archive/pipes/article-archive-id.pipe.ts` - ArticleArchive용 파이프

**서비스 레이어**
- `ArticlesService.resolveCanonicalArticleId()` 메서드 추가
- `ArticleArchiveService.resolveCanonicalArticleArchiveId()` 메서드 추가
- 12개 메서드 시그니처 업데이트 (`number` → `string`)

**컨트롤러 업데이트**
- `ArticlesController` - `ArticleIdParamPipe` 적용
- `ArticleArchiveController` - `ArticleArchiveIdParamPipe` 적용

### 기술적 구현

**Dual ID System**
```typescript
// Article Entity
@PrimaryKey({ fieldName: 'article_id', type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
articleId!: string;

@Property({
fieldName: 'legacy_article_id',
type: 'integer',
nullable: true,
unique: true,
})
legacyArticleId?: number;
```

**자동 ID 변환 Flow**
```
Client Request (UUID or Legacy ID)
  ↓
ArticleIdParamPipe
  ↓
resolveCanonicalArticleId()
  ↓
UUID String (Canonical Form)
  ↓
Service Layer
```

**하위호환성 전략**
```typescript
// ContentService - Chrome Extension 호환
return {
id: article.legacyArticleId?.toString() || article.articleId.toString(),
type: 'article',
// ...
}
```

### Breaking Changes

**None** - 완전한 하위호환성 유지:
- ✅ Chrome Extension 코드 변경 불필요
- ✅ 기존 Legacy ID로 API 호출 가능
- ✅ 응답 포맷 변경 없음 (legacyArticleId 반환)

## 🗃️ 데이터베이스 변경사항

### 마이그레이션 파일
`src/migrations/Migration20251110000000_articles_uuid_migration.sql`

## 📦 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음 (30+ 에러 수정 완료)



## 🔗 참고사항

