### PR TITLE
[CHI-431] Tag UUID 마이그레이션 및 하위호환성 구현

### DIFF
--- a/src/api/content/dto/unified-content-response.dto.ts
+++ b/src/api/content/dto/unified-content-response.dto.ts
@@ -1,8 +1,17 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class TagDto {
-  @ApiProperty({ example: 1 })
-  tagId: number;
+  @ApiProperty({
+    description: 'Tag ID (UUID)',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  tagId: string;
+
+  @ApiPropertyOptional({
+    description: 'Legacy numeric tag ID (for backward compatibility)',
+    example: 1,
+  })
+  legacyTagId?: number;
 
   @ApiProperty({ example: 'javascript' })
   name: string;

--- a/src/api/scraps/dto/scrap-response.dto.ts
+++ b/src/api/scraps/dto/scrap-response.dto.ts
@@ -115,17 +115,19 @@ export class ScrapResponseDto {
     items: {
       type: 'object',
       properties: {
-        tagId: { type: 'number', example: 1 },
+        tagId: { type: 'string', example: '550e8400-e29b-41d4-a716-446655440000' },
+        legacyTagId: { type: 'number', example: 1 },
         name: { type: 'string', example: 'Technology' },
       },
     },
     example: [
-      { tagId: 1, name: 'Technology' },
-      { tagId: 2, name: 'API' },
+      { tagId: '550e8400-e29b-41d4-a716-446655440000', legacyTagId: 1, name: 'Technology' },
+      { tagId: '550e8400-e29b-41d4-a716-446655440001', legacyTagId: 2, name: 'API' },
     ],
   })
   tags?: {
-    tagId: number;
+    tagId: string;
+    legacyTagId?: number;
     name: string;
   }[];
 
@@ -292,14 +294,16 @@ export class ScrapSummaryDto {
     items: {
       type: 'object',
       properties: {
-        tagId: { type: 'number', example: 1 },
+        tagId: { type: 'string', example: '550e8400-e29b-41d4-a716-446655440000' },
+        legacyTagId: { type: 'number', example: 1 },
         name: { type: 'string', example: 'Technology' },
       },
     },
-    example: [{ tagId: 1, name: 'Technology' }],
+    example: [{ tagId: '550e8400-e29b-41d4-a716-446655440000', legacyTagId: 1, name: 'Technology' }],
   })
   tags?: {
-    tagId: number;
+    tagId: string;
+    legacyTagId?: number;
     name: string;
   }[];
 

--- a/src/api/tags/tags.controller.ts
+++ b/src/api/tags/tags.controller.ts
@@ -8,7 +8,6 @@ import {
   Delete,
   Version,
   Query,
-  ParseIntPipe,
   HttpException,
   HttpStatus,
   UseGuards,
@@ -18,6 +17,7 @@ import { TagsService } from '../../tags/tags.service';
 import { CreateTagDto } from './dto/create-tag.dto';
 import { UpdateTagDto } from './dto/update-tag.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { TagIdParamPipe } from '../../tags/pipes/tag-id.pipe';
 
 @UseGuards(JwtAuthGuard)
 @Controller('tags')
@@ -74,7 +74,7 @@ export class TagsController {
    */
   @Version('1')
   @Get(':tagId')
-  async findOne(@Param('tagId', ParseIntPipe) tagId: number) {
+  async findOne(@Param('tagId', TagIdParamPipe) tagId: string) {
     try {
       const tag = await this.tagsService.findOne(tagId);
       if (!tag) {
@@ -95,7 +95,7 @@ export class TagsController {
   @Version('1')
   @Put(':tagId')
   async update(
-    @Param('tagId', ParseIntPipe) tagId: number,
+    @Param('tagId', TagIdParamPipe) tagId: string,
     @Body() updateTagDto: UpdateTagDto,
   ) {
     try {
@@ -117,7 +117,7 @@ export class TagsController {
    */
   @Version('1')
   @Delete(':tagId')
-  async remove(@Param('tagId', ParseIntPipe) tagId: number) {
+  async remove(@Param('tagId', TagIdParamPipe) tagId: string) {
     try {
       await this.tagsService.remove(tagId);
       return { message: 'Tag deleted successfully' };

--- a/src/content/content.service.ts
+++ b/src/content/content.service.ts
@@ -432,10 +432,11 @@ export class ContentService {
 
     // PERFORMANCE FIX: Check if tags collection is initialized before accessing
     // This prevents N+1 queries when tags are not properly populated
-    let tags: Array<{ tagId: number; name: string }> | undefined = undefined;
+    let tags: Array<{ tagId: string; legacyTagId?: number; name: string }> | undefined = undefined;
     if (scrap.tags && scrap.tags.isInitialized()) {
       tags = scrap.tags.getItems().map((tag) => ({
         tagId: tag.tagId,
+        legacyTagId: tag.legacyTagId,
         name: tag.name,
       }));
     }
@@ -484,10 +485,11 @@ export class ContentService {
 
     // PERFORMANCE FIX: Check if tags collection is initialized before accessing
     // This prevents N+1 queries when tags are not properly populated
-    let tags: Array<{ tagId: number; name: string }> | undefined = undefined;
+    let tags: Array<{ tagId: string; legacyTagId?: number; name: string }> | undefined = undefined;
     if (article.tags && article.tags.isInitialized()) {
       tags = article.tags.getItems().map((tag) => ({
         tagId: tag.tagId,
+        legacyTagId: tag.legacyTagId,
         name: tag.name,
       }));
     }

--- a/src/library-items/library-items.service.ts
+++ b/src/library-items/library-items.service.ts
@@ -12,6 +12,10 @@ import {
   UserIdentifierLike,
   buildUserFilterFromInput,
 } from '../users/utils/user-identifier.util';
+import {
+  TagIdentifierLike,
+} from '../tags/tags.service';
+import { buildTagWhereClause } from '../tags/utils/tag-identifier.util';
 
 export type LibraryItemType = 'SCRAP' | 'UPLOAD';
 
@@ -208,7 +212,7 @@ export class LibraryItemsService {
   async removeTag(
     itemId: string,
     itemType: LibraryItemType,
-    tagId: number,
+    tagId: TagIdentifierLike,
     userId: UserIdentifierLike,
   ): Promise<void> {
     if (itemType === 'SCRAP') {
@@ -232,13 +236,13 @@ export class LibraryItemsService {
 
     if (itemType === 'SCRAP') {
       tag = await this.tagRepository.findOne({
-        tagId,
+        ...buildTagWhereClause(String(tagId)),
         user: buildUserFilterFromInput(userId) as any,
         scrap: { scrapId: itemId },
       });
     } else {
       tag = await this.tagRepository.findOne({
-        tagId,
+        ...buildTagWhereClause(String(tagId)),
         user: buildUserFilterFromInput(userId) as any,
         scrap: { scrapId: itemId },
       });

--- a/src/migrations/Migration20251110120000_tags_uuid_migration.sql
+++ b/src/migrations/Migration20251110120000_tags_uuid_migration.sql
@@ -1,0 +1,169 @@
+-- Migration: Tags PK from Serial Integer to UUID
+-- Date: 2025-11-10
+-- Description: Migrates tags table to UUID while preserving legacy IDs
+
+-- ============================================================================
+-- FORWARD MIGRATION (UP)
+-- ============================================================================
+
+-- 1. Ensure UUID extension is enabled
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- ============================================================================
+-- TAGS TABLE MIGRATION
+-- ============================================================================
+
+-- 2. Add new UUID column and legacy ID column to tags
+ALTER TABLE tags
+  ADD COLUMN tag_uuid UUID DEFAULT uuid_generate_v4(),
+  ADD COLUMN legacy_tag_id INTEGER;
+
+-- 3. Copy existing IDs to legacy column
+UPDATE tags SET legacy_tag_id = tag_id;
+
+-- 4. Create sequence for auto-incrementing legacy IDs
+CREATE SEQUENCE IF NOT EXISTS tags_legacy_tag_id_seq;
+SELECT setval('tags_legacy_tag_id_seq', COALESCE((SELECT MAX(legacy_tag_id) FROM tags), 0));
+
+-- 5. Set default for legacy_tag_id to use sequence
+ALTER TABLE tags ALTER COLUMN legacy_tag_id SET DEFAULT nextval('tags_legacy_tag_id_seq');
+
+-- 6. Add unique constraint on legacy_tag_id
+ALTER TABLE tags ADD CONSTRAINT tags_legacy_tag_id_unique UNIQUE (legacy_tag_id);
+
+-- 7. Drop existing foreign key constraints
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_user_id_foreign CASCADE;
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_user_id_fkey CASCADE;
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_scrap_id_foreign CASCADE;
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_scrap_id_fkey CASCADE;
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_article_id_foreign CASCADE;
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_article_id_fkey CASCADE;
+
+-- 8. Drop primary key constraint
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_pkey CASCADE;
+
+-- 9. Drop the old tag_id column
+ALTER TABLE tags DROP COLUMN tag_id;
+
+-- 10. Rename tag_uuid to tag_id
+ALTER TABLE tags RENAME COLUMN tag_uuid TO tag_id;
+
+-- 11. Add primary key constraint on new UUID column
+ALTER TABLE tags ADD PRIMARY KEY (tag_id);
+
+-- 12. Create indexes for performance
+CREATE INDEX IF NOT EXISTS idx_tags_legacy_tag_id ON tags(legacy_tag_id);
+CREATE INDEX IF NOT EXISTS idx_tags_user_id ON tags(user_id);
+CREATE INDEX IF NOT EXISTS idx_tags_scrap_id ON tags(scrap_id);
+CREATE INDEX IF NOT EXISTS idx_tags_article_id ON tags(article_id);
+CREATE INDEX IF NOT EXISTS idx_tags_name ON tags(name);
+
+-- 13. Recreate foreign key constraints
+ALTER TABLE tags
+  ADD CONSTRAINT tags_user_id_foreign
+  FOREIGN KEY (user_id) REFERENCES users(user_id)
+  ON DELETE CASCADE;
+
+ALTER TABLE tags
+  ADD CONSTRAINT tags_scrap_id_foreign
+  FOREIGN KEY (scrap_id) REFERENCES scraps(scrap_id)
+  ON DELETE CASCADE;
+
+ALTER TABLE tags
+  ADD CONSTRAINT tags_article_id_foreign
+  FOREIGN KEY (article_id) REFERENCES articles(article_id)
+  ON DELETE CASCADE;
+
+-- ============================================================================
+-- DATA VALIDATION
+-- ============================================================================
+
+-- Verify all tags have UUIDs
+DO $$
+DECLARE
+  null_uuid_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO null_uuid_count FROM tags WHERE tag_id IS NULL;
+  IF null_uuid_count > 0 THEN
+    RAISE EXCEPTION 'Migration failed: % tags have NULL UUID', null_uuid_count;
+  END IF;
+  RAISE NOTICE 'Validation passed: All tags have UUIDs';
+END $$;
+
+-- Verify legacy IDs are unique
+DO $$
+DECLARE
+  duplicate_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO duplicate_count
+  FROM (
+    SELECT legacy_tag_id, COUNT(*)
+    FROM tags
+    WHERE legacy_tag_id IS NOT NULL
+    GROUP BY legacy_tag_id
+    HAVING COUNT(*) > 1
+  ) duplicates;
+  IF duplicate_count > 0 THEN
+    RAISE EXCEPTION 'Migration failed: Duplicate legacy_tag_id found';
+  END IF;
+  RAISE NOTICE 'Validation passed: All legacy IDs are unique';
+END $$;
+
+-- ============================================================================
+-- ROLLBACK MIGRATION (DOWN)
+-- ============================================================================
+-- Run the following commands to rollback if needed:
+
+/*
+-- 1. Add integer tag_id column back
+ALTER TABLE tags ADD COLUMN tag_id_int INTEGER;
+
+-- 2. Populate with legacy IDs
+UPDATE tags SET tag_id_int = legacy_tag_id;
+
+-- 3. Drop foreign key constraints
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_user_id_foreign;
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_scrap_id_foreign;
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_article_id_foreign;
+
+-- 4. Rename UUID column
+ALTER TABLE tags RENAME COLUMN tag_id TO tag_uuid;
+
+-- 5. Rename integer column to tag_id
+ALTER TABLE tags RENAME COLUMN tag_id_int TO tag_id;
+
+-- 6. Drop primary key on UUID
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_pkey;
+
+-- 7. Add primary key on integer
+ALTER TABLE tags ADD PRIMARY KEY (tag_id);
+
+-- 8. Drop legacy columns and sequence
+ALTER TABLE tags DROP COLUMN IF EXISTS tag_uuid;
+ALTER TABLE tags DROP COLUMN IF EXISTS legacy_tag_id;
+DROP SEQUENCE IF EXISTS tags_legacy_tag_id_seq;
+
+-- 9. Drop UUID-related indexes
+DROP INDEX IF EXISTS idx_tags_legacy_tag_id;
+
+-- 10. Recreate foreign key constraints
+ALTER TABLE tags
+  ADD CONSTRAINT tags_user_id_foreign
+  FOREIGN KEY (user_id) REFERENCES users(user_id)
+  ON DELETE CASCADE;
+
+ALTER TABLE tags
+  ADD CONSTRAINT tags_scrap_id_foreign
+  FOREIGN KEY (scrap_id) REFERENCES scraps(scrap_id)
+  ON DELETE CASCADE;
+
+ALTER TABLE tags
+  ADD CONSTRAINT tags_article_id_foreign
+  FOREIGN KEY (article_id) REFERENCES articles(article_id)
+  ON DELETE CASCADE;
+
+-- 11. Verify rollback
+SELECT COUNT(*) as total_tags,
+       COUNT(CASE WHEN tag_id IS NULL THEN 1 END) as null_ids
+FROM tags;
+*/

--- a/src/tags/entities/tag.entity.ts
+++ b/src/tags/entities/tag.entity.ts
@@ -30,8 +30,11 @@ export class Tag {
     }
   }
 
-  @PrimaryKey({ name: 'tag_id' })
-  tagId: number;
+  @PrimaryKey({ name: 'tag_id', type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
+  tagId: string;
+
+  @Property({ name: 'legacy_tag_id', type: 'integer', nullable: true })
+  legacyTagId?: number;
 
   @Property({ name: 'name', type: 'varchar', length: 100 })
   name: string;

--- a/src/tags/pipes/tag-id.pipe.ts
+++ b/src/tags/pipes/tag-id.pipe.ts
@@ -1,0 +1,76 @@
+/**
+ * Tag ID Parameter Pipe
+ *
+ * NestJS pipe for automatically validating and normalizing tag IDs in route parameters.
+ * Supports both UUID and legacy integer IDs for backward compatibility.
+ *
+ * @example
+ * // In controller
+ * @Get(':tagId')
+ * async findOne(@Param('tagId', TagIdParamPipe) tagId: string) {
+ *   // tagId is validated and normalized
+ * }
+ */
+
+import {
+  PipeTransform,
+  Injectable,
+  BadRequestException,
+  ArgumentMetadata,
+} from '@nestjs/common';
+import {
+  isValidTagId,
+  normalizeTagId,
+  getTagIdType,
+} from '../utils/tag-identifier.util';
+
+@Injectable()
+export class TagIdParamPipe implements PipeTransform<string, string> {
+  transform(value: string, metadata: ArgumentMetadata): string {
+    if (!value) {
+      throw new BadRequestException('Tag ID is required');
+    }
+
+    const normalizedId = normalizeTagId(value);
+
+    if (!isValidTagId(normalizedId)) {
+      throw new BadRequestException(
+        `Invalid tag ID format: "${value}". Expected UUID or integer.`,
+      );
+    }
+
+    const idType = getTagIdType(normalizedId);
+
+    // Log for debugging (remove in production if needed)
+    if (process.env.NODE_ENV === 'development') {
+      console.log(
+        `[TagIdParamPipe] Validated ${idType} tag ID: ${normalizedId}`,
+      );
+    }
+
+    return normalizedId;
+  }
+}
+
+/**
+ * Optional variant that allows null/undefined values
+ * Useful for optional query parameters
+ */
+@Injectable()
+export class OptionalTagIdPipe implements PipeTransform<string, string | null> {
+  transform(value: string, metadata: ArgumentMetadata): string | null {
+    if (!value) {
+      return null;
+    }
+
+    const normalizedId = normalizeTagId(value);
+
+    if (!isValidTagId(normalizedId)) {
+      throw new BadRequestException(
+        `Invalid tag ID format: "${value}". Expected UUID or integer.`,
+      );
+    }
+
+    return normalizedId;
+  }
+}

--- a/src/tags/tags.service.ts
+++ b/src/tags/tags.service.ts
@@ -15,6 +15,12 @@ import {
   ScrapIdentifierLike,
   buildScrapFilterFromInput,
 } from '../scraps/utils/scrap-identifier.util';
+import {
+  buildTagWhereClause,
+  normalizeTagId,
+} from './utils/tag-identifier.util';
+
+export type TagIdentifierLike = string | number;
 
 @Injectable()
 export class TagsService {
@@ -27,6 +33,31 @@ export class TagsService {
     @InjectRepository(Scrap)
     private readonly scrapRepository: EntityRepository<Scrap>,
   ) {}
+
+  /**
+   * Resolve canonical tag ID (UUID) from various input formats
+   * Supports both UUID and legacy integer IDs
+   *
+   * @param tagId - Tag identifier (UUID string or legacy integer)
+   * @returns Canonical UUID string
+   * @throws Error if tag not found
+   */
+  async resolveCanonicalTagId(tagId: TagIdentifierLike): Promise<string> {
+    const normalizedId = normalizeTagId(tagId);
+    const whereClause = buildTagWhereClause(normalizedId);
+
+    const tag = await this.tagRepository.findOne(whereClause, {
+      fields: ['tagId'],
+    });
+
+    if (!tag) {
+      throw new Error(
+        `Tag not found with identifier: ${normalizedId}`,
+      );
+    }
+
+    return tag.tagId;
+  }
 
   async create(
     createTagDto: CreateTagDto,
@@ -74,13 +105,13 @@ export class TagsService {
     });
   }
 
-  async findOne(tagId: number): Promise<Tag | null> {
-    return await this.tagRepository.findOne(
-      { tagId },
-      {
-        populate: ['user', 'scrap'],
-      },
-    );
+  async findOne(tagId: TagIdentifierLike): Promise<Tag | null> {
+    const normalizedId = normalizeTagId(tagId);
+    const whereClause = buildTagWhereClause(normalizedId);
+
+    return await this.tagRepository.findOne(whereClause, {
+      populate: ['user', 'scrap'],
+    });
   }
 
   async findByUser(userId: UserIdentifierLike): Promise<Tag[]> {
@@ -110,8 +141,14 @@ export class TagsService {
     );
   }
 
-  async update(tagId: number, updateTagDto: UpdateTagDto): Promise<Tag | null> {
-    const tag = await this.tagRepository.findOne({ tagId });
+  async update(
+    tagId: TagIdentifierLike,
+    updateTagDto: UpdateTagDto,
+  ): Promise<Tag | null> {
+    const normalizedId = normalizeTagId(tagId);
+    const whereClause = buildTagWhereClause(normalizedId);
+
+    const tag = await this.tagRepository.findOne(whereClause);
     if (!tag) {
       return null;
     }
@@ -120,8 +157,11 @@ export class TagsService {
     return tag;
   }
 
-  async remove(tagId: number): Promise<void> {
-    const tag = await this.tagRepository.findOne({ tagId });
+  async remove(tagId: TagIdentifierLike): Promise<void> {
+    const normalizedId = normalizeTagId(tagId);
+    const whereClause = buildTagWhereClause(normalizedId);
+
+    const tag = await this.tagRepository.findOne(whereClause);
     if (tag) {
       await this.em.removeAndFlush(tag);
     }

--- a/src/tags/utils/tag-identifier.util.ts
+++ b/src/tags/utils/tag-identifier.util.ts
@@ -1,0 +1,98 @@
+/**
+ * Tag Identifier Utility
+ *
+ * Handles conversion and validation between UUID and legacy integer IDs for tags.
+ * Supports backward compatibility with Chrome extension using integer IDs.
+ */
+
+import { FilterQuery } from '@mikro-orm/core';
+import { Tag } from '../entities/tag.entity';
+
+/**
+ * Check if a string is a valid UUID
+ */
+export function isUuid(id: string): boolean {
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(id);
+}
+
+/**
+ * Check if a string is a valid integer
+ */
+export function isInteger(id: string): boolean {
+  return /^\d+$/.test(id) && !isNaN(parseInt(id, 10));
+}
+
+/**
+ * Normalize tag ID to string format
+ * Handles both UUID and integer inputs
+ */
+export function normalizeTagId(id: string | number): string {
+  if (typeof id === 'number') {
+    return id.toString();
+  }
+  return id;
+}
+
+/**
+ * Build MikroORM filter query for finding tag by ID
+ * Automatically detects UUID vs legacy integer ID
+ *
+ * @param id - Tag identifier (UUID or legacy integer as string)
+ * @returns FilterQuery object for MikroORM
+ *
+ * @example
+ * // UUID lookup
+ * buildTagWhereClause('550e8400-e29b-41d4-a716-446655440000')
+ * // Returns: { tagId: '550e8400-e29b-41d4-a716-446655440000' }
+ *
+ * // Legacy integer lookup
+ * buildTagWhereClause('123')
+ * // Returns: { legacyTagId: 123 }
+ */
+export function buildTagWhereClause(id: string): FilterQuery<Tag> {
+  const normalizedId = normalizeTagId(id);
+
+  if (isUuid(normalizedId)) {
+    return { tagId: normalizedId };
+  }
+
+  if (isInteger(normalizedId)) {
+    return { legacyTagId: parseInt(normalizedId, 10) };
+  }
+
+  // If neither UUID nor integer, assume it's a malformed UUID and try anyway
+  // This will fail at DB level with proper error message
+  return { tagId: normalizedId };
+}
+
+/**
+ * Validate tag ID format
+ *
+ * @param id - Tag identifier to validate
+ * @returns true if valid UUID or integer
+ */
+export function isValidTagId(id: string): boolean {
+  const normalizedId = normalizeTagId(id);
+  return isUuid(normalizedId) || isInteger(normalizedId);
+}
+
+/**
+ * Get tag identifier type for logging/debugging
+ *
+ * @param id - Tag identifier
+ * @returns 'uuid', 'legacy', or 'invalid'
+ */
+export function getTagIdType(id: string): 'uuid' | 'legacy' | 'invalid' {
+  const normalizedId = normalizeTagId(id);
+
+  if (isUuid(normalizedId)) {
+    return 'uuid';
+  }
+
+  if (isInteger(normalizedId)) {
+    return 'legacy';
+  }
+
+  return 'invalid';
+}


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-431](https://linear.app/chill-mato/issue/CHI-431/be-tag-uuid-마이그레이션-완료)

## 📋 변경사항 요약

Tag 엔티티의 Primary Key를 Integer에서 UUID로 마이그레이션하여 시스템 전체의 UUID 통일성을 확보

### 주요 변경사항

#### 데이터베이스 스키마
- Tag 테이블 PK를 UUID로 변경
- `legacy_tag_id` 컬럼 추가로 하위 호환성 보장
- Foreign key constraints 재생성
- 성능 최적화를 위한 인덱스 추가

#### 엔티티 & 타입 시스템
- `Tag` 엔티티: UUID PK + `defaultRaw: 'uuid_generate_v4()'` 추가
- `TagIdentifierLike = string | number` 타입 정의
- UUID/legacy ID 모두 지원하는 유연한 타입 시스템

#### Service & Controller Layer
- `TagsService.resolveCanonicalTagId()` 메서드로 ID 자동 변환
- `TagIdParamPipe`로 모든 엔드포인트에서 자동 검증/변환
- ContentService, LibraryItemsService 타입 업데이트

#### 새로운 유틸리티
- `src/tags/utils/tag-identifier.util.ts`: ID 검증/정규화 함수
- `src/tags/pipes/tag-id.pipe.ts`: 자동 ID 검증 파이프

### 하위 호환성
- Chrome extension에서 기존 integer ID 계속 사용 가능
- API 응답에 `legacyTagId` 포함
- UUID/legacy ID 모두 API 입력값으로 허용

## 🗃️ 데이터베이스 변경사항

### Migration SQL
- 파일: `src/migrations/Migration20251110120000_tags_uuid_migration.sql`
- 13단계 마이그레이션 (UUID PK 전환, legacy ID 보존)
- 데이터 검증 로직 포함
- 롤백 스크립트 제공

## 📦 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음