### PR TITLE
[CHI-432] WritingStyle/WritingStyleExample UUID 마이그레이션

### DIFF
--- a/src/api/articles/dto/generate-article-v2.dto.ts
+++ b/src/api/articles/dto/generate-article-v2.dto.ts
@@ -6,6 +6,7 @@ import {
   IsString,
   IsNumber,
 } from 'class-validator';
+import { WritingStyleIdentifierLike } from '../../../writing-styles/utils/writing-style-identifier.util';
 
 export class ScrapWithOptionalCommentV2 {
   @ApiProperty({
@@ -46,10 +47,13 @@ export class GenerateArticleV2Dto {
   @IsOptional()
   articleStructureTemplate?: TemplateSectionV2Dto[];
 
-  @ApiProperty()
-  @IsNumber()
+  @ApiProperty({
+    description: 'Writing Style ID (UUID or legacy integer)',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    required: false,
+  })
   @IsOptional()
-  writingStyleId?: number;
+  writingStyleId?: WritingStyleIdentifierLike;
 }
 
 export interface TemplateSectionV2Dto {

--- a/src/api/articles/dto/generate-article-v3.dto.ts
+++ b/src/api/articles/dto/generate-article-v3.dto.ts
@@ -7,6 +7,7 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { WritingStyleIdentifierLike } from '../../../writing-styles/utils/writing-style-identifier.util';
 
 export class ScrapWithCommentDto {
   @ApiProperty({
@@ -72,8 +73,10 @@ export class GenerateArticleV3Dto {
   @IsOptional()
   articleStructureTemplate?: any[];
 
-  @ApiPropertyOptional({ description: '문체 스타일 ID' })
+  @ApiPropertyOptional({
+    description: '문체 스타일 ID (UUID or legacy integer)',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   @IsOptional()
-  @IsNumber()
-  writingStyleId?: number;
+  writingStyleId?: WritingStyleIdentifierLike;
 }

--- a/src/api/articles/dto/generate-article.dto.ts
+++ b/src/api/articles/dto/generate-article.dto.ts
@@ -6,6 +6,7 @@ import {
   IsString,
   IsNumber,
 } from 'class-validator';
+import { WritingStyleIdentifierLike } from '../../../writing-styles/utils/writing-style-identifier.util';
 
 export class ScrapWithOptionalComment {
   @ApiProperty({
@@ -46,10 +47,13 @@ export class GenerateArticleDto {
   @IsOptional()
   articleStructureTemplate?: TemplateSectionDto[];
 
-  @ApiProperty()
-  @IsNumber()
+  @ApiProperty({
+    description: 'Writing Style ID (UUID or legacy integer)',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    required: false,
+  })
   @IsOptional()
-  writingStyleId?: number;
+  writingStyleId?: WritingStyleIdentifierLike;
 }
 
 export interface TemplateSectionDto {

--- a/src/api/articles/dto/regenerate-article-v3.dto.ts
+++ b/src/api/articles/dto/regenerate-article-v3.dto.ts
@@ -8,6 +8,7 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { WritingStyleIdentifierLike } from '../../../writing-styles/utils/writing-style-identifier.util';
 
 export class UploadWithUsagePromptDto {
   @ApiPropertyOptional({
@@ -72,13 +73,12 @@ export class RegenerateArticleV3Dto {
 
   @ApiPropertyOptional({
     description:
-      'Writing style ID. Pass null to remove, omit to keep existing, or provide ID to change',
-    example: 123,
+      'Writing style ID (UUID or legacy integer). Pass null to remove, omit to keep existing, or provide ID to change',
+    example: '550e8400-e29b-41d4-a716-446655440000',
     nullable: true,
   })
   @IsOptional()
-  @IsNumber()
-  writingStyleId?: number | null;
+  writingStyleId?: WritingStyleIdentifierLike | null;
 
   @ApiPropertyOptional({
     description:

--- a/src/api/writing-styles/writing-styles.controller.ts
+++ b/src/api/writing-styles/writing-styles.controller.ts
@@ -13,6 +13,7 @@ import { WritingStylesService } from '../../writing-styles/writing-styles.servic
 import { CreateWritingStyleDto } from './dto/create-writing-style.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { User } from '../../users/entities/user.entity';
+import { WritingStyleIdParamPipe } from '../../writing-styles/pipes/writing-style-id.pipe';
 
 @Controller('api/v1/writing-styles')
 @UseGuards(JwtAuthGuard)
@@ -35,14 +36,17 @@ export class WritingStylesController {
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string, @Req() req: any) {
+  findOne(
+    @Param('id', WritingStyleIdParamPipe) id: string,
+    @Req() req: any,
+  ) {
     const userId = req.user.id; // JWT에서 사용자 ID 추출
-    return this.writingStylesService.findOne(+id, userId);
+    return this.writingStylesService.findOne(id, userId);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string, @Req() req: any) {
+  remove(@Param('id', WritingStyleIdParamPipe) id: string, @Req() req: any) {
     const userId = req.user.id; // JWT에서 사용자 ID 추출
-    return this.writingStylesService.remove(+id, userId);
+    return this.writingStylesService.remove(id, userId);
   }
 }

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -45,6 +45,11 @@ import {
   ScrapIdentifier,
   isUuid as isScrapUuid,
 } from '../scraps/utils/scrap-identifier.util';
+import {
+  WritingStyleIdentifierLike,
+  buildWritingStyleWhereClause,
+  normalizeWritingStyleId,
+} from '../writing-styles/utils/writing-style-identifier.util';
 import { FilterQuery } from '@mikro-orm/core';
 // Analytics tracking migrated to extension client (PostHog).
 
@@ -188,16 +193,26 @@ export class ArticlesService {
 
     let writingStyleExampleContents: string[] = [];
     if (generateDto.writingStyleId) {
+      const normalizedId = normalizeWritingStyleId(generateDto.writingStyleId);
+      const whereClause = buildWritingStyleWhereClause(normalizedId);
+
       const writingStyleExamples =
         await this.writingStyleExampleRepository.find(
-          { writingStyle: { id: generateDto.writingStyleId, user: user } },
+          {
+            writingStyle: {
+              ...(whereClause as any),
+              user: user,
+            },
+          },
           { populate: ['writingStyle'] },
         );
       writingStyleExampleContents = writingStyleExamples.map(
         (example) => example.content,
       );
-      if (!writingStyleExamples) {
-        throw new NotFoundException('쓰기 스타일을 찾을 수 없습니다.');
+      if (!writingStyleExamples || writingStyleExamples.length === 0) {
+        throw new NotFoundException(
+          `Writing style with ID ${normalizedId} not found`,
+        );
       }
     }
 
@@ -281,20 +296,25 @@ export class ArticlesService {
    * @private
    */
   private async validateAndGetWritingStyle(
-    writingStyleId: number | undefined,
+    writingStyleId: WritingStyleIdentifierLike | undefined,
     userId: string,
   ): Promise<WritingStyle | undefined> {
     if (!writingStyleId) {
       return undefined;
     }
 
+    const normalizedId = normalizeWritingStyleId(writingStyleId);
+    const whereClause = buildWritingStyleWhereClause(normalizedId);
+
     const writingStyle = await this.writingStyleRepository.findOne({
-      id: writingStyleId,
+      ...(whereClause as any),
       user: { userId: userId },
     });
 
     if (!writingStyle) {
-      throw new NotFoundException('문체 스타일을 찾을 수 없습니다.');
+      throw new NotFoundException(
+        `Writing style with ID ${normalizedId} not found or not accessible`,
+      );
     }
 
     return writingStyle;
@@ -920,11 +940,17 @@ export class ArticlesService {
       // 문체 예시 준비
       let writingStyleExampleContents: string[] = [];
       if (generateDto.writingStyleId) {
+        const normalizedStyleId = normalizeWritingStyleId(
+          generateDto.writingStyleId,
+        );
+        const styleWhereClause =
+          buildWritingStyleWhereClause(normalizedStyleId);
+
         const writingStyleExamples =
           await this.writingStyleExampleRepository.find(
             {
               writingStyle: {
-                id: generateDto.writingStyleId,
+                ...(styleWhereClause as any),
                 user: article.user,
               },
             },
@@ -1245,11 +1271,17 @@ export class ArticlesService {
       // 문체 예시 준비
       let writingStyleExampleContents: string[] = [];
       if (generateDto.writingStyleId) {
+        const normalizedStyleId = normalizeWritingStyleId(
+          generateDto.writingStyleId,
+        );
+        const styleWhereClause =
+          buildWritingStyleWhereClause(normalizedStyleId);
+
         const writingStyleExamples =
           await this.writingStyleExampleRepository.find(
             {
               writingStyle: {
-                id: generateDto.writingStyleId,
+                ...(styleWhereClause as any),
                 user: article.user,
               },
             },
@@ -1482,10 +1514,16 @@ export class ArticlesService {
 
           let writingStyleExampleContents: string[] = [];
           if (generateDto.writingStyleId) {
+            const normalizedStyleId = normalizeWritingStyleId(
+              generateDto.writingStyleId,
+            );
+            const styleWhereClause =
+              buildWritingStyleWhereClause(normalizedStyleId);
+
             const examples = await this.writingStyleExampleRepository.find(
               {
                 writingStyle: {
-                  id: generateDto.writingStyleId,
+                  ...(styleWhereClause as any),
                   user,
                 },
               },
@@ -1741,14 +1779,17 @@ export class ArticlesService {
         if (dto.writingStyleId === null) {
           writingStyle = null; // Explicit removal
         } else {
+          const normalizedId = normalizeWritingStyleId(dto.writingStyleId);
+          const whereClause = buildWritingStyleWhereClause(normalizedId);
+
           writingStyle = await trx.findOne(WritingStyle, {
-            id: dto.writingStyleId,
+            ...(whereClause as any),
             user: { userId } as any,
           });
 
           if (!writingStyle) {
             throw new BadRequestException(
-              `Writing style with ID ${dto.writingStyleId} not found or not accessible`,
+              `Writing style with ID ${normalizedId} not found or not accessible`,
             );
           }
         }
@@ -1887,10 +1928,17 @@ export class ArticlesService {
         writingStyle !== undefined ? writingStyle : article.writingStyle;
 
       if (finalWritingStyle) {
+        const styleWhereClause = buildWritingStyleWhereClause(
+          finalWritingStyle.id,
+        );
+
         const writingStyleExamples =
           await this.writingStyleExampleRepository.find(
             {
-              writingStyle: { id: finalWritingStyle.id, user: { userId } as any },
+              writingStyle: {
+                ...(styleWhereClause as any),
+                user: { userId } as any,
+              },
             },
             { populate: ['writingStyle'] },
           );
@@ -2157,13 +2205,16 @@ export class ArticlesService {
               if (dto.writingStyleId === null) {
                 article.writingStyle = undefined;
               } else {
+                const normalizedId = normalizeWritingStyleId(dto.writingStyleId);
+                const whereClause = buildWritingStyleWhereClause(normalizedId);
+
                 const writingStyle = await trx.findOne(WritingStyle, {
-                  id: dto.writingStyleId,
+                  ...(whereClause as any),
                   user: { userId } as any,
                 });
                 if (!writingStyle) {
                   throw new NotFoundException(
-                    `WritingStyle with ID ${dto.writingStyleId} not found`,
+                    `WritingStyle with ID ${normalizedId} not found`,
                   );
                 }
                 article.writingStyle = writingStyle;

--- a/src/migrations/Migration20251110130000_writing_styles_uuid_migration.sql
+++ b/src/migrations/Migration20251110130000_writing_styles_uuid_migration.sql
@@ -1,0 +1,322 @@
+-- Migration: WritingStyles & WritingStyleExamples PK from Serial Integer to UUID
+-- Date: 2025-11-10
+-- Description: Migrates writing_styles and writing_style_examples tables to UUID while preserving legacy IDs
+
+-- ============================================================================
+-- FORWARD MIGRATION (UP)
+-- ============================================================================
+
+-- 1. Ensure UUID extension is enabled
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- ============================================================================
+-- WRITING_STYLES TABLE MIGRATION
+-- ============================================================================
+
+-- 2. Add new UUID column and legacy ID column to writing_styles
+ALTER TABLE writing_styles
+  ADD COLUMN writing_style_uuid UUID DEFAULT uuid_generate_v4(),
+  ADD COLUMN legacy_writing_style_id INTEGER;
+
+-- 3. Copy existing IDs to legacy column
+UPDATE writing_styles SET legacy_writing_style_id = id;
+
+-- 4. Create sequence for auto-incrementing legacy IDs
+CREATE SEQUENCE IF NOT EXISTS writing_styles_legacy_id_seq;
+SELECT setval('writing_styles_legacy_id_seq', COALESCE((SELECT MAX(legacy_writing_style_id) FROM writing_styles), 0));
+
+-- 5. Set default for legacy_writing_style_id to use sequence
+ALTER TABLE writing_styles ALTER COLUMN legacy_writing_style_id SET DEFAULT nextval('writing_styles_legacy_id_seq');
+
+-- 6. Add unique constraint on legacy_writing_style_id
+ALTER TABLE writing_styles ADD CONSTRAINT writing_styles_legacy_id_unique UNIQUE (legacy_writing_style_id);
+
+-- ============================================================================
+-- WRITING_STYLE_EXAMPLES TABLE MIGRATION (Must happen before dropping writing_styles PK)
+-- ============================================================================
+
+-- 7. Add new UUID column and legacy ID column to writing_style_examples
+ALTER TABLE writing_style_examples
+  ADD COLUMN example_uuid UUID DEFAULT uuid_generate_v4(),
+  ADD COLUMN legacy_example_id INTEGER;
+
+-- 8. Copy existing IDs to legacy column
+UPDATE writing_style_examples SET legacy_example_id = id;
+
+-- 9. Create sequence for auto-incrementing legacy example IDs
+CREATE SEQUENCE IF NOT EXISTS writing_style_examples_legacy_id_seq;
+SELECT setval('writing_style_examples_legacy_id_seq', COALESCE((SELECT MAX(legacy_example_id) FROM writing_style_examples), 0));
+
+-- 10. Set default for legacy_example_id to use sequence
+ALTER TABLE writing_style_examples ALTER COLUMN legacy_example_id SET DEFAULT nextval('writing_style_examples_legacy_id_seq');
+
+-- 11. Add unique constraint on legacy_example_id
+ALTER TABLE writing_style_examples ADD CONSTRAINT writing_style_examples_legacy_id_unique UNIQUE (legacy_example_id);
+
+-- ============================================================================
+-- DROP FOREIGN KEY CONSTRAINTS (writing_style_examples -> writing_styles)
+-- ============================================================================
+
+-- 12. Drop foreign key constraint from writing_style_examples to writing_styles
+ALTER TABLE writing_style_examples DROP CONSTRAINT IF EXISTS writing_style_examples_writing_style_id_foreign CASCADE;
+ALTER TABLE writing_style_examples DROP CONSTRAINT IF EXISTS writing_style_examples_writing_style_id_fkey CASCADE;
+
+-- ============================================================================
+-- MIGRATE WRITING_STYLES PRIMARY KEY
+-- ============================================================================
+
+-- 13. Drop foreign key constraints on writing_styles
+ALTER TABLE writing_styles DROP CONSTRAINT IF EXISTS writing_styles_user_id_foreign CASCADE;
+ALTER TABLE writing_styles DROP CONSTRAINT IF EXISTS writing_styles_user_id_fkey CASCADE;
+
+-- 14. Drop primary key constraint on writing_styles
+ALTER TABLE writing_styles DROP CONSTRAINT IF EXISTS writing_styles_pkey CASCADE;
+
+-- 15. Drop the old id column from writing_styles
+ALTER TABLE writing_styles DROP COLUMN id;
+
+-- 16. Rename writing_style_uuid to id
+ALTER TABLE writing_styles RENAME COLUMN writing_style_uuid TO id;
+
+-- 17. Add primary key constraint on new UUID column
+ALTER TABLE writing_styles ADD PRIMARY KEY (id);
+
+-- ============================================================================
+-- MIGRATE WRITING_STYLE_EXAMPLES PRIMARY KEY
+-- ============================================================================
+
+-- 18. Drop primary key constraint on writing_style_examples
+ALTER TABLE writing_style_examples DROP CONSTRAINT IF EXISTS writing_style_examples_pkey CASCADE;
+
+-- 19. Drop the old id column from writing_style_examples
+ALTER TABLE writing_style_examples DROP COLUMN id;
+
+-- 20. Rename example_uuid to id
+ALTER TABLE writing_style_examples RENAME COLUMN example_uuid TO id;
+
+-- 21. Add primary key constraint on new UUID column
+ALTER TABLE writing_style_examples ADD PRIMARY KEY (id);
+
+-- ============================================================================
+-- UPDATE FOREIGN KEY COLUMN IN WRITING_STYLE_EXAMPLES
+-- ============================================================================
+
+-- 22. Add new UUID foreign key column
+ALTER TABLE writing_style_examples ADD COLUMN writing_style_id_uuid UUID;
+
+-- 23. Populate new FK column by joining on legacy IDs
+UPDATE writing_style_examples wse
+SET writing_style_id_uuid = ws.id
+FROM writing_styles ws
+WHERE wse.writing_style_id = ws.legacy_writing_style_id;
+
+-- 24. Drop old integer FK column
+ALTER TABLE writing_style_examples DROP COLUMN writing_style_id;
+
+-- 25. Rename UUID FK column to writing_style_id
+ALTER TABLE writing_style_examples RENAME COLUMN writing_style_id_uuid TO writing_style_id;
+
+-- 26. Set NOT NULL constraint on FK
+ALTER TABLE writing_style_examples ALTER COLUMN writing_style_id SET NOT NULL;
+
+-- ============================================================================
+-- RECREATE INDEXES AND CONSTRAINTS
+-- ============================================================================
+
+-- 27. Create indexes for performance
+CREATE INDEX IF NOT EXISTS idx_writing_styles_legacy_id ON writing_styles(legacy_writing_style_id);
+CREATE INDEX IF NOT EXISTS idx_writing_styles_user_id ON writing_styles(user_id);
+CREATE INDEX IF NOT EXISTS idx_writing_styles_name ON writing_styles(name);
+
+CREATE INDEX IF NOT EXISTS idx_writing_style_examples_legacy_id ON writing_style_examples(legacy_example_id);
+CREATE INDEX IF NOT EXISTS idx_writing_style_examples_writing_style_id ON writing_style_examples(writing_style_id);
+CREATE INDEX IF NOT EXISTS idx_writing_style_examples_order ON writing_style_examples("order");
+
+-- 28. Recreate foreign key constraints
+ALTER TABLE writing_styles
+  ADD CONSTRAINT writing_styles_user_id_foreign
+  FOREIGN KEY (user_id) REFERENCES users(user_id)
+  ON DELETE CASCADE;
+
+ALTER TABLE writing_style_examples
+  ADD CONSTRAINT writing_style_examples_writing_style_id_foreign
+  FOREIGN KEY (writing_style_id) REFERENCES writing_styles(id)
+  ON DELETE CASCADE;
+
+-- ============================================================================
+-- DATA VALIDATION
+-- ============================================================================
+
+-- Verify all writing_styles have UUIDs
+DO $$
+DECLARE
+  null_uuid_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO null_uuid_count FROM writing_styles WHERE id IS NULL;
+  IF null_uuid_count > 0 THEN
+    RAISE EXCEPTION 'Migration failed: % writing_styles have NULL UUID', null_uuid_count;
+  END IF;
+  RAISE NOTICE 'Validation passed: All writing_styles have UUIDs';
+END $$;
+
+-- Verify all writing_style_examples have UUIDs
+DO $$
+DECLARE
+  null_uuid_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO null_uuid_count FROM writing_style_examples WHERE id IS NULL;
+  IF null_uuid_count > 0 THEN
+    RAISE EXCEPTION 'Migration failed: % writing_style_examples have NULL UUID', null_uuid_count;
+  END IF;
+  RAISE NOTICE 'Validation passed: All writing_style_examples have UUIDs';
+END $$;
+
+-- Verify legacy IDs are unique for writing_styles
+DO $$
+DECLARE
+  duplicate_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO duplicate_count
+  FROM (
+    SELECT legacy_writing_style_id, COUNT(*)
+    FROM writing_styles
+    WHERE legacy_writing_style_id IS NOT NULL
+    GROUP BY legacy_writing_style_id
+    HAVING COUNT(*) > 1
+  ) duplicates;
+  IF duplicate_count > 0 THEN
+    RAISE EXCEPTION 'Migration failed: Duplicate legacy_writing_style_id found';
+  END IF;
+  RAISE NOTICE 'Validation passed: All writing_styles legacy IDs are unique';
+END $$;
+
+-- Verify legacy IDs are unique for writing_style_examples
+DO $$
+DECLARE
+  duplicate_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO duplicate_count
+  FROM (
+    SELECT legacy_example_id, COUNT(*)
+    FROM writing_style_examples
+    WHERE legacy_example_id IS NOT NULL
+    GROUP BY legacy_example_id
+    HAVING COUNT(*) > 1
+  ) duplicates;
+  IF duplicate_count > 0 THEN
+    RAISE EXCEPTION 'Migration failed: Duplicate legacy_example_id found';
+  END IF;
+  RAISE NOTICE 'Validation passed: All writing_style_examples legacy IDs are unique';
+END $$;
+
+-- Verify foreign key integrity
+DO $$
+DECLARE
+  orphaned_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO orphaned_count
+  FROM writing_style_examples wse
+  LEFT JOIN writing_styles ws ON wse.writing_style_id = ws.id
+  WHERE ws.id IS NULL;
+  IF orphaned_count > 0 THEN
+    RAISE EXCEPTION 'Migration failed: % orphaned writing_style_examples found', orphaned_count;
+  END IF;
+  RAISE NOTICE 'Validation passed: All writing_style_examples have valid writing_style_id';
+END $$;
+
+-- ============================================================================
+-- ROLLBACK MIGRATION (DOWN)
+-- ============================================================================
+-- Run the following commands to rollback if needed:
+
+/*
+-- ROLLBACK: WRITING_STYLE_EXAMPLES TABLE
+
+-- 1. Add integer ID column back
+ALTER TABLE writing_style_examples ADD COLUMN id_int INTEGER;
+
+-- 2. Populate with legacy IDs
+UPDATE writing_style_examples SET id_int = legacy_example_id;
+
+-- 3. Add integer FK column back
+ALTER TABLE writing_style_examples ADD COLUMN writing_style_id_int INTEGER;
+
+-- 4. Populate FK with writing_styles legacy IDs
+UPDATE writing_style_examples wse
+SET writing_style_id_int = ws.legacy_writing_style_id
+FROM writing_styles ws
+WHERE wse.writing_style_id = ws.id;
+
+-- 5. Drop FK constraint
+ALTER TABLE writing_style_examples DROP CONSTRAINT IF EXISTS writing_style_examples_writing_style_id_foreign;
+
+-- 6. Rename UUID columns
+ALTER TABLE writing_style_examples RENAME COLUMN id TO id_uuid;
+ALTER TABLE writing_style_examples RENAME COLUMN writing_style_id TO writing_style_id_uuid;
+
+-- 7. Rename integer columns to original names
+ALTER TABLE writing_style_examples RENAME COLUMN id_int TO id;
+ALTER TABLE writing_style_examples RENAME COLUMN writing_style_id_int TO writing_style_id;
+
+-- 8. Drop primary key on UUID
+ALTER TABLE writing_style_examples DROP CONSTRAINT IF EXISTS writing_style_examples_pkey;
+
+-- 9. Add primary key on integer
+ALTER TABLE writing_style_examples ADD PRIMARY KEY (id);
+
+-- 10. Drop UUID columns and legacy columns
+ALTER TABLE writing_style_examples DROP COLUMN IF EXISTS id_uuid;
+ALTER TABLE writing_style_examples DROP COLUMN IF EXISTS writing_style_id_uuid;
+ALTER TABLE writing_style_examples DROP COLUMN IF EXISTS legacy_example_id;
+DROP SEQUENCE IF EXISTS writing_style_examples_legacy_id_seq;
+DROP INDEX IF EXISTS idx_writing_style_examples_legacy_id;
+
+-- ROLLBACK: WRITING_STYLES TABLE
+
+-- 11. Add integer ID column back
+ALTER TABLE writing_styles ADD COLUMN id_int INTEGER;
+
+-- 12. Populate with legacy IDs
+UPDATE writing_styles SET id_int = legacy_writing_style_id;
+
+-- 13. Drop FK constraints
+ALTER TABLE writing_styles DROP CONSTRAINT IF EXISTS writing_styles_user_id_foreign;
+
+-- 14. Rename UUID column
+ALTER TABLE writing_styles RENAME COLUMN id TO id_uuid;
+
+-- 15. Rename integer column to id
+ALTER TABLE writing_styles RENAME COLUMN id_int TO id;
+
+-- 16. Drop primary key on UUID
+ALTER TABLE writing_styles DROP CONSTRAINT IF EXISTS writing_styles_pkey;
+
+-- 17. Add primary key on integer
+ALTER TABLE writing_styles ADD PRIMARY KEY (id);
+
+-- 18. Drop UUID columns and legacy columns
+ALTER TABLE writing_styles DROP COLUMN IF EXISTS id_uuid;
+ALTER TABLE writing_styles DROP COLUMN IF EXISTS legacy_writing_style_id;
+DROP SEQUENCE IF EXISTS writing_styles_legacy_id_seq;
+DROP INDEX IF EXISTS idx_writing_styles_legacy_id;
+
+-- 19. Recreate foreign key constraints
+ALTER TABLE writing_styles
+  ADD CONSTRAINT writing_styles_user_id_foreign
+  FOREIGN KEY (user_id) REFERENCES users(user_id)
+  ON DELETE CASCADE;
+
+ALTER TABLE writing_style_examples
+  ADD CONSTRAINT writing_style_examples_writing_style_id_foreign
+  FOREIGN KEY (writing_style_id) REFERENCES writing_styles(id)
+  ON DELETE CASCADE;
+
+-- 20. Verify rollback
+SELECT COUNT(*) as total_styles,
+       COUNT(CASE WHEN id IS NULL THEN 1 END) as null_ids
+FROM writing_styles;
+
+SELECT COUNT(*) as total_examples,
+       COUNT(CASE WHEN id IS NULL THEN 1 END) as null_ids
+FROM writing_style_examples;
+*/

--- a/src/migrations/Migration20251110140000_articles_writing_style_fk_uuid.sql
+++ b/src/migrations/Migration20251110140000_articles_writing_style_fk_uuid.sql
@@ -1,0 +1,96 @@
+-- Migration: Articles writing_style_id FK from Integer to UUID
+-- Date: 2025-11-10
+-- Description: Updates articles.writing_style_id FK to reference writing_styles UUID PK
+
+-- ============================================================================
+-- FORWARD MIGRATION (UP)
+-- ============================================================================
+
+-- 1. Add temporary UUID column for writing_style_id
+ALTER TABLE articles ADD COLUMN writing_style_id_uuid UUID;
+
+-- 2. Populate new UUID column by joining with writing_styles legacy IDs
+UPDATE articles a
+SET writing_style_id_uuid = ws.id
+FROM writing_styles ws
+WHERE a.writing_style_id = ws.legacy_writing_style_id;
+
+-- 3. Drop old FK constraint if exists
+ALTER TABLE articles DROP CONSTRAINT IF EXISTS articles_writing_style_id_foreign CASCADE;
+ALTER TABLE articles DROP CONSTRAINT IF EXISTS articles_writing_style_id_fkey CASCADE;
+
+-- 4. Drop old integer column
+ALTER TABLE articles DROP COLUMN writing_style_id;
+
+-- 5. Rename UUID column to writing_style_id
+ALTER TABLE articles RENAME COLUMN writing_style_id_uuid TO writing_style_id;
+
+-- 6. Recreate FK constraint to writing_styles UUID PK
+ALTER TABLE articles
+  ADD CONSTRAINT articles_writing_style_id_foreign
+  FOREIGN KEY (writing_style_id) REFERENCES writing_styles(id)
+  ON DELETE SET NULL;
+
+-- 7. Create index for performance
+CREATE INDEX IF NOT EXISTS idx_articles_writing_style_id ON articles(writing_style_id);
+
+-- ============================================================================
+-- DATA VALIDATION
+-- ============================================================================
+
+-- Verify no orphaned writing_style_id references
+DO $$
+DECLARE
+  orphaned_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO orphaned_count
+  FROM articles a
+  LEFT JOIN writing_styles ws ON a.writing_style_id = ws.id
+  WHERE a.writing_style_id IS NOT NULL AND ws.id IS NULL;
+
+  IF orphaned_count > 0 THEN
+    RAISE EXCEPTION 'Migration failed: % articles have orphaned writing_style_id', orphaned_count;
+  END IF;
+
+  RAISE NOTICE 'Validation passed: All articles have valid writing_style_id references';
+END $$;
+
+-- ============================================================================
+-- ROLLBACK MIGRATION (DOWN)
+-- ============================================================================
+-- Run the following commands to rollback if needed:
+
+/*
+-- 1. Add integer column back
+ALTER TABLE articles ADD COLUMN writing_style_id_int INTEGER;
+
+-- 2. Populate with legacy IDs
+UPDATE articles a
+SET writing_style_id_int = ws.legacy_writing_style_id
+FROM writing_styles ws
+WHERE a.writing_style_id = ws.id;
+
+-- 3. Drop FK constraint
+ALTER TABLE articles DROP CONSTRAINT IF EXISTS articles_writing_style_id_foreign;
+
+-- 4. Drop UUID column
+ALTER TABLE articles DROP COLUMN writing_style_id;
+
+-- 5. Rename integer column to writing_style_id
+ALTER TABLE articles RENAME COLUMN writing_style_id_int TO writing_style_id;
+
+-- 6. Recreate FK constraint to integer PK (if needed - assuming old schema)
+-- Note: This may fail if writing_styles no longer has integer PK
+-- ALTER TABLE articles
+--   ADD CONSTRAINT articles_writing_style_id_foreign
+--   FOREIGN KEY (writing_style_id) REFERENCES writing_styles(id)
+--   ON DELETE SET NULL;
+
+-- 7. Drop UUID index
+DROP INDEX IF EXISTS idx_articles_writing_style_id;
+
+-- 8. Verify rollback
+SELECT COUNT(*) as total_articles,
+       COUNT(writing_style_id) as articles_with_style
+FROM articles;
+*/

--- a/src/writing-styles/entities/writing-style-example.entity.ts
+++ b/src/writing-styles/entities/writing-style-example.entity.ts
@@ -3,10 +3,13 @@ import { WritingStyle } from './writing-style.entity';
 
 @Entity({ tableName: 'writing_style_examples' })
 export class WritingStyleExample {
-  @PrimaryKey()
-  id: number;
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
+  id: string;
 
-  @ManyToOne(() => WritingStyle)
+  @Property({ name: 'legacy_example_id', nullable: true, unique: true })
+  legacyExampleId?: number;
+
+  @ManyToOne(() => WritingStyle, { fieldName: 'writing_style_id' })
   writingStyle: WritingStyle;
 
   @Property({ type: 'text' })

--- a/src/writing-styles/entities/writing-style.entity.ts
+++ b/src/writing-styles/entities/writing-style.entity.ts
@@ -11,8 +11,11 @@ import { WritingStyleExample } from './writing-style-example.entity';
 
 @Entity({ tableName: 'writing_styles' })
 export class WritingStyle {
-  @PrimaryKey()
-  id: number;
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
+  id: string;
+
+  @Property({ name: 'legacy_writing_style_id', nullable: true, unique: true })
+  legacyWritingStyleId?: number;
 
   @Property()
   name: string;

--- a/src/writing-styles/pipes/writing-style-id.pipe.ts
+++ b/src/writing-styles/pipes/writing-style-id.pipe.ts
@@ -1,0 +1,78 @@
+/**
+ * WritingStyle ID Parameter Pipe
+ *
+ * NestJS pipe for automatically validating and normalizing writing style IDs in route parameters.
+ * Supports both UUID and legacy integer IDs for backward compatibility.
+ *
+ * @example
+ * // In controller
+ * @Get(':id')
+ * async findOne(@Param('id', WritingStyleIdParamPipe) id: string) {
+ *   // id is validated and normalized
+ * }
+ */
+
+import {
+  PipeTransform,
+  Injectable,
+  BadRequestException,
+  ArgumentMetadata,
+} from '@nestjs/common';
+import {
+  isValidWritingStyleId,
+  normalizeWritingStyleId,
+  getWritingStyleIdType,
+} from '../utils/writing-style-identifier.util';
+
+@Injectable()
+export class WritingStyleIdParamPipe implements PipeTransform<string, string> {
+  transform(value: string, metadata: ArgumentMetadata): string {
+    if (!value) {
+      throw new BadRequestException('Writing style ID is required');
+    }
+
+    const normalizedId = normalizeWritingStyleId(value);
+
+    if (!isValidWritingStyleId(normalizedId)) {
+      throw new BadRequestException(
+        `Invalid writing style ID format: "${value}". Expected UUID or integer.`,
+      );
+    }
+
+    const idType = getWritingStyleIdType(normalizedId);
+
+    // Log for debugging (remove in production if needed)
+    if (process.env.NODE_ENV === 'development') {
+      console.log(
+        `[WritingStyleIdParamPipe] Validated ${idType} writing style ID: ${normalizedId}`,
+      );
+    }
+
+    return normalizedId;
+  }
+}
+
+/**
+ * Optional variant that allows null/undefined values
+ * Useful for optional query parameters
+ */
+@Injectable()
+export class OptionalWritingStyleIdPipe
+  implements PipeTransform<string, string | null>
+{
+  transform(value: string, metadata: ArgumentMetadata): string | null {
+    if (!value) {
+      return null;
+    }
+
+    const normalizedId = normalizeWritingStyleId(value);
+
+    if (!isValidWritingStyleId(normalizedId)) {
+      throw new BadRequestException(
+        `Invalid writing style ID format: "${value}". Expected UUID or integer.`,
+      );
+    }
+
+    return normalizedId;
+  }
+}

--- a/src/writing-styles/utils/writing-style-identifier.util.ts
+++ b/src/writing-styles/utils/writing-style-identifier.util.ts
@@ -1,0 +1,114 @@
+/**
+ * WritingStyle Identifier Utility
+ *
+ * Handles conversion and validation between UUID and legacy integer IDs for writing styles.
+ * Supports backward compatibility with Chrome extension using integer IDs.
+ */
+
+import { FilterQuery } from '@mikro-orm/core';
+import { WritingStyle } from '../entities/writing-style.entity';
+
+/**
+ * Type alias for writing style identifiers (UUID or legacy integer)
+ */
+export type WritingStyleIdentifier = string | number;
+export type WritingStyleIdentifierLike =
+  | WritingStyleIdentifier
+  | null
+  | undefined;
+
+/**
+ * Check if a string is a valid UUID
+ */
+export function isUuid(id: string): boolean {
+  const uuidRegex =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(id);
+}
+
+/**
+ * Check if a string is a valid integer
+ */
+export function isInteger(id: string): boolean {
+  return /^\d+$/.test(id) && !isNaN(parseInt(id, 10));
+}
+
+/**
+ * Normalize writing style ID to string format
+ * Handles both UUID and integer inputs
+ */
+export function normalizeWritingStyleId(
+  id: WritingStyleIdentifierLike,
+): string {
+  if (id === null || id === undefined) {
+    throw new Error('Writing style ID cannot be null or undefined');
+  }
+
+  if (typeof id === 'number') {
+    return id.toString();
+  }
+
+  return id;
+}
+
+/**
+ * Build MikroORM filter query for finding writing style by ID
+ * Automatically detects UUID vs legacy integer ID
+ *
+ * @param id - WritingStyle identifier (UUID or legacy integer as string)
+ * @returns FilterQuery object for MikroORM
+ *
+ * @example
+ * // UUID lookup
+ * buildWritingStyleWhereClause('550e8400-e29b-41d4-a716-446655440000')
+ * // Returns: { id: '550e8400-e29b-41d4-a716-446655440000' }
+ *
+ * // Legacy integer lookup
+ * buildWritingStyleWhereClause('123')
+ * // Returns: { legacyWritingStyleId: 123 }
+ */
+export function buildWritingStyleWhereClause(
+  id: string,
+): FilterQuery<WritingStyle> {
+  if (isUuid(id)) {
+    return { id };
+  }
+
+  if (isInteger(id)) {
+    return { legacyWritingStyleId: parseInt(id, 10) };
+  }
+
+  // If neither UUID nor integer, assume it's a malformed UUID and try anyway
+  // This will fail at DB level with proper error message
+  return { id };
+}
+
+/**
+ * Validate writing style ID format
+ *
+ * @param id - WritingStyle identifier to validate
+ * @returns true if valid UUID or integer
+ */
+export function isValidWritingStyleId(id: string): boolean {
+  return isUuid(id) || isInteger(id);
+}
+
+/**
+ * Get writing style identifier type for logging/debugging
+ *
+ * @param id - WritingStyle identifier
+ * @returns 'uuid', 'legacy', or 'invalid'
+ */
+export function getWritingStyleIdType(
+  id: string,
+): 'uuid' | 'legacy' | 'invalid' {
+  if (isUuid(id)) {
+    return 'uuid';
+  }
+
+  if (isInteger(id)) {
+    return 'legacy';
+  }
+
+  return 'invalid';
+}

--- a/src/writing-styles/writing-styles.service.ts
+++ b/src/writing-styles/writing-styles.service.ts
@@ -10,6 +10,11 @@ import {
   UserIdentifierLike,
   buildUserFilterFromInput,
 } from '../users/utils/user-identifier.util';
+import {
+  WritingStyleIdentifierLike,
+  buildWritingStyleWhereClause,
+  normalizeWritingStyleId,
+} from './utils/writing-style-identifier.util';
 import TurndownService = require('turndown');
 
 @Injectable()
@@ -26,6 +31,30 @@ export class WritingStylesService {
     private readonly em: EntityManager,
   ) {
     this.turndownService = new TurndownService();
+  }
+
+  /**
+   * Resolve canonical UUID for a writing style ID (supports both UUID and legacy integer)
+   *
+   * @param id - Writing style identifier (UUID or legacy integer)
+   * @returns Canonical UUID string
+   * @throws NotFoundException if writing style not found
+   */
+  async resolveCanonicalWritingStyleId(
+    id: WritingStyleIdentifierLike,
+  ): Promise<string> {
+    const normalizedId = normalizeWritingStyleId(id);
+    const whereClause = buildWritingStyleWhereClause(normalizedId);
+
+    const writingStyle = await this.writingStyleRepository.findOne(whereClause);
+
+    if (!writingStyle) {
+      throw new NotFoundException(
+        `Writing style with ID ${normalizedId} not found`,
+      );
+    }
+
+    return writingStyle.id; // Always return UUID
   }
 
   async create(
@@ -75,32 +104,61 @@ export class WritingStylesService {
     return this.writingStyleRepository.find({ user: user });
   }
 
-  async findOne(id: number, userId: UserIdentifierLike) {
+  async findOne(
+    id: WritingStyleIdentifierLike,
+    userId: UserIdentifierLike,
+  ): Promise<WritingStyle> {
     const user = await this.userRepository.findOne(
       buildUserFilterFromInput(userId),
     );
     if (!user) {
       throw new Error('User not found');
     }
-    const style = await this.writingStyleRepository.findOne({ id, user: user });
+
+    const normalizedId = normalizeWritingStyleId(id);
+    const whereClause = buildWritingStyleWhereClause(normalizedId);
+
+    const style = await this.writingStyleRepository.findOne({
+      ...(whereClause as any),
+      user: user,
+    });
+
     if (!style) {
-      throw new NotFoundException(`WritingStyle with ID ${id} not found.`);
+      throw new NotFoundException(
+        `WritingStyle with ID ${normalizedId} not found.`,
+      );
     }
     return style;
   }
 
-  async remove(id: number, userId: UserIdentifierLike) {
+  async remove(
+    id: WritingStyleIdentifierLike,
+    userId: UserIdentifierLike,
+  ): Promise<{ message: string }> {
     const user = await this.userRepository.findOne(
       buildUserFilterFromInput(userId),
     );
     if (!user) {
       throw new Error('User not found');
     }
-    const style = await this.writingStyleRepository.findOne({ id, user: user });
+
+    const normalizedId = normalizeWritingStyleId(id);
+    const whereClause = buildWritingStyleWhereClause(normalizedId);
+
+    const style = await this.writingStyleRepository.findOne({
+      ...(whereClause as any),
+      user: user,
+    });
+
     if (!style) {
-      throw new NotFoundException(`WritingStyle with ID ${id} not found.`);
+      throw new NotFoundException(
+        `WritingStyle with ID ${normalizedId} not found.`,
+      );
     }
+
     await this.em.removeAndFlush(style);
-    return { message: `WritingStyle with ID ${id} deleted successfully.` };
+    return {
+      message: `WritingStyle with ID ${normalizedId} deleted successfully.`,
+    };
   }
 }


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-432](https://linear.app/chill-mato/issue/CHI-432/)

## 📋 변경사항 요약

WritingStyle 및 WritingStyleExample 엔티티를 Integer PK에서 UUID PK로 마이그레이션. Chrome extension과의 하위호환성을 위해 dual-ID 시스템을 구현.

### 주요 변경사항

#### **데이터베이스 마이그레이션**
- `Migration20251110130000_writing_styles_uuid_migration.sql`
  - writing_styles 및 writing_style_examples 테이블 UUID PK 적용
  - legacy_writing_style_id, legacy_example_id 컬럼 추가
  - 데이터 무결성 검증 및 rollback 스크립트 포함
  
- `Migration20251110140000_articles_writing_style_fk_uuid.sql`
  - Articles 테이블의 writing_style_id FK 컬럼을 Integer → UUID로 변환
  - 기존 데이터 마이그레이션 (legacy ID 기반 join)

#### **엔티티 업데이트**
- WritingStyle: UUID PK + legacy integer ID
- WritingStyleExample: UUID PK + legacy integer ID

#### **유틸리티 및 파이프 (신규)**
- `writing-style-identifier.util.ts`: UUID/Integer ID 자동 감지 및 변환
- `writing-style-id.pipe.ts`: NestJS 파이프로 자동 검증

#### **서비스 & 컨트롤러**
- WritingStylesService: resolveCanonicalWritingStyleId() 메서드 추가
- ArticlesService: 7개 위치에서 writing style 조회 로직 업데이트
- WritingStylesController: WritingStyleIdParamPipe 적용

#### **DTO 업데이트**
- GenerateArticleDto, GenerateArticleV2Dto, GenerateArticleV3Dto, RegenerateArticleV3Dto
- 모두 WritingStyleIdentifierLike 타입으로 변경

### 하위 호환성
- Chrome extension의 기존 Integer ID 계속 사용 가능  
- API는 UUID와 Integer ID 모두 자동 처리  
- 응답에는 UUID와 legacy ID 모두 포함  

## 🗃️ 데이터베이스 변경사항

### 마이그레이션 파일
1. **Migration20251110130000_writing_styles_uuid_migration.sql**
   - writing_styles 테이블: id (UUID PK), legacy_writing_style_id (Integer)
   - writing_style_examples 테이블: id (UUID PK), legacy_example_id (Integer)
   - writing_style_id FK를 UUID로 업데이트

2. **Migration20251110140000_articles_writing_style_fk_uuid.sql**
   - articles.writing_style_id 컬럼: Integer → UUID
   - FK 제약조건 재생성
1->2 순서로 스크립트 실행

## 📦 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음