### PR TITLE
[CHI-435] Job PK를 serial integer에서 UUID로 변경

### DIFF
--- a/src/migrations/Migration20251110170000_job_uuid_migration.sql
+++ b/src/migrations/Migration20251110170000_job_uuid_migration.sql
@@ -1,0 +1,77 @@
+-- Migration: Job PK from Integer to UUID
+-- Date: 2025-11-10
+-- Description: Updates jobs.job_id from serial integer to UUID PK
+-- Special Case: jobUuid field already exists and is used for ALL queries
+-- Strategy: Promote existing job_uuid to PK, drop unused job_id
+
+-- ============================================================================
+-- FORWARD MIGRATION (UP)
+-- ============================================================================
+
+-- Step 1: Enable UUID extension if not already enabled
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Step 2: Drop existing primary key constraint
+ALTER TABLE jobs DROP CONSTRAINT IF EXISTS jobs_pkey CASCADE;
+
+-- Step 3: Drop old integer job_id column (unused in codebase)
+ALTER TABLE jobs DROP COLUMN job_id;
+
+-- Step 4: Rename job_uuid to job_id (making it the new PK)
+ALTER TABLE jobs RENAME COLUMN job_uuid TO job_id;
+
+-- Step 5: Set UUID column as primary key
+ALTER TABLE jobs ADD PRIMARY KEY (job_id);
+
+-- ============================================================================
+-- DATA VALIDATION
+-- ============================================================================
+
+-- Verify all records have valid UUID primary keys
+DO $$
+DECLARE
+  invalid_uuids INTEGER;
+BEGIN
+  -- Check for invalid UUIDs (cast to text for regex check)
+  SELECT COUNT(*) INTO invalid_uuids
+  FROM jobs
+  WHERE job_id::text !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
+
+  IF invalid_uuids > 0 THEN
+    RAISE EXCEPTION 'Migration failed: % records have invalid UUID format', invalid_uuids;
+  END IF;
+
+  RAISE NOTICE 'Validation passed: All jobs records migrated successfully';
+END $$;
+
+-- Display migration summary
+DO $$
+DECLARE
+  total_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO total_count FROM jobs;
+
+  RAISE NOTICE '=== Migration Summary ===';
+  RAISE NOTICE 'Total jobs records: %', total_count;
+  RAISE NOTICE 'All records now use UUID primary keys (promoted from job_uuid)';
+  RAISE NOTICE 'Note: No code changes needed - codebase already uses job_uuid for all queries';
+END $$;
+
+-- ============================================================================
+-- ROLLBACK MIGRATION (DOWN)
+-- ============================================================================
+-- Run the following commands to rollback if needed:
+
+/*
+-- Note: Job is a queue tracking entity that is never queried by ID directly.
+-- The integer job_id was never used in the codebase - all queries use job_uuid.
+-- Rollback requires recreating all job records from scratch.
+-- This migration is irreversible in practice - recommend database restore from backup.
+
+-- If rollback is absolutely necessary:
+-- 1. Backup current jobs data (export job_id, job_type, status, user_id, etc.)
+-- 2. Drop jobs table
+-- 3. Recreate with integer PK
+-- 4. Generate new job_uuid values and restore data
+-- 5. Note: Any external references to job UUIDs will be broken
+*/

--- a/src/queue/entities/job-status.entity.ts
+++ b/src/queue/entities/job-status.entity.ts
@@ -14,11 +14,8 @@ export enum JobStatus {
 
 @Entity({ tableName: 'jobs' })
 export class Job {
-  @PrimaryKey()
-  jobId!: number;
-
-  @Property()
-  jobUuid!: string; // Unique identifier for tracking
+  @PrimaryKey({ fieldName: 'job_id', type: 'uuid', defaultRaw: 'uuid_generate_v4()' })
+  jobUuid!: string; // Unique identifier for tracking (promoted to PK)
 
   @Enum(() => JobType)
   jobType!: JobType;


### PR DESCRIPTION
## 연관 이슈
Closes: [CHI-435](https://linear.app/chill-mato/issue/CHI-435/)

## 변경사항 요약
Job 엔티티의 기존 `jobUuid` 필드를 PK로 승격. 코드베이스에서 모든 쿼리가 이미 `jobUuid` 사용 중이므로 코드 변경 불필요.

## 데이터베이스 변경사항
- Job 테이블 PK를 integer에서 UUID로 변경 (job_uuid → job_id로 rename)
- 마이그레이션: `Migration20251110170000_job_uuid_migration.sql`
- Legacy ID 없음 (integer PK 미사용)

## 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음