### PR TITLE
[CHI-457] article chat 기능 보강

### DIFF
--- a/src/ai-workflows/dto/regenerate.dto.ts
+++ b/src/ai-workflows/dto/regenerate.dto.ts
@@ -33,6 +33,7 @@ export interface RegenerateArticleOutput {
   title: string;
   content: string;
   changesSummary: string;
+  modelName?: string;
   promptTokens?: number;
   completionTokens?: number;
   totalTokens?: number;

--- a/src/ai-workflows/services/article-regenerator.service.ts
+++ b/src/ai-workflows/services/article-regenerator.service.ts
@@ -41,6 +41,9 @@ export class ArticleRegeneratorService {
     const text = this.extractMessageText(response?.content ?? '');
     const result = this.parseResponse(text);
 
+    // Set model name
+    result.modelName = REGENERATOR_MODEL;
+
     // Extract token usage information from AIMessage's usage_metadata
     const usageMetadata = (response as any)?.usage_metadata;
 

--- a/src/api/article-chat/article-chat.controller.ts
+++ b/src/api/article-chat/article-chat.controller.ts
@@ -1,0 +1,85 @@
+import { Controller, Get, Post, Param, UseGuards, Req } from '@nestjs/common';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { ArticleChatService } from '../../article-chat/services/article-chat.service';
+import {
+  SessionListItemDto,
+  SessionMessagesDto,
+} from '../../article-chat/dto/session-list.dto';
+
+@Controller('api/v1/article-chat')
+@UseGuards(JwtAuthGuard)
+export class ArticleChatController {
+  constructor(private readonly articleChatService: ArticleChatService) {}
+
+  /**
+   * 아티클의 모든 채팅 세션 목록 조회
+   * GET /api/v1/article-chat/articles/:articleId/sessions
+   */
+  @Get('articles/:articleId/sessions')
+  async getArticleSessions(
+    @Param('articleId') articleId: string,
+    @Req() req: any,
+  ): Promise<SessionListItemDto[]> {
+    const userId = req.user.userId;
+    const sessions = await this.articleChatService.getSessionsForArticle(
+      articleId,
+      userId,
+    );
+
+    return sessions.map((session) => ({
+      sessionId: session.sessionId,
+      title: session.title,
+      summary: session.summary,
+      messageCount: session.messageCount,
+      lastMessageAt: session.lastMessageAt,
+      isActive: session.isActive,
+      createdAt: session.createdAt,
+    }));
+  }
+
+  /**
+   * 특정 세션의 메시지 조회
+   * GET /api/v1/article-chat/sessions/:sessionId/messages
+   */
+  @Get('sessions/:sessionId/messages')
+  async getSessionMessages(
+    @Param('sessionId') sessionId: string,
+  ): Promise<SessionMessagesDto> {
+    const messages = await this.articleChatService.getSessionMessages(
+      sessionId,
+    );
+
+    return {
+      sessionId,
+      messages: messages.map((msg) => ({
+        messageId: msg.messageId,
+        role: msg.role,
+        content: msg.content,
+        timestamp: msg.createdAt,
+        modelName: msg.modelName,
+        totalTokens: msg.totalTokens,
+      })),
+    };
+  }
+
+  /**
+   * 새 채팅 세션 생성
+   * POST /api/v1/article-chat/articles/:articleId/sessions/new
+   */
+  @Post('articles/:articleId/sessions/new')
+  async createNewSession(
+    @Param('articleId') articleId: string,
+    @Req() req: any,
+  ): Promise<{ sessionId: string; message: string }> {
+    const userId = req.user.userId;
+    const newSession = await this.articleChatService.createNewSession(
+      articleId,
+      userId,
+    );
+
+    return {
+      sessionId: newSession.sessionId,
+      message: 'New chat session created successfully',
+    };
+  }
+}

--- a/src/api/article-chat/article-chat.controller.ts
+++ b/src/api/article-chat/article-chat.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Param, UseGuards, Req } from '@nestjs/common';
+import { Controller, Get, Post, Param, UseGuards, Req, Version } from '@nestjs/common';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { ArticleChatService } from '../../article-chat/services/article-chat.service';
 import {
@@ -6,7 +6,7 @@ import {
   SessionMessagesDto,
 } from '../../article-chat/dto/session-list.dto';
 
-@Controller('api/v1/article-chat')
+@Controller('article-chat')
 @UseGuards(JwtAuthGuard)
 export class ArticleChatController {
   constructor(private readonly articleChatService: ArticleChatService) {}
@@ -15,6 +15,7 @@ export class ArticleChatController {
    * 아티클의 모든 채팅 세션 목록 조회
    * GET /api/v1/article-chat/articles/:articleId/sessions
    */
+  @Version('1')
   @Get('articles/:articleId/sessions')
   async getArticleSessions(
     @Param('articleId') articleId: string,
@@ -41,6 +42,7 @@ export class ArticleChatController {
    * 특정 세션의 메시지 조회
    * GET /api/v1/article-chat/sessions/:sessionId/messages
    */
+  @Version('1')
   @Get('sessions/:sessionId/messages')
   async getSessionMessages(
     @Param('sessionId') sessionId: string,
@@ -66,6 +68,7 @@ export class ArticleChatController {
    * 새 채팅 세션 생성
    * POST /api/v1/article-chat/articles/:articleId/sessions/new
    */
+  @Version('1')
   @Post('articles/:articleId/sessions/new')
   async createNewSession(
     @Param('articleId') articleId: string,

--- a/src/api/article-chat/article-chat.controller.ts
+++ b/src/api/article-chat/article-chat.controller.ts
@@ -21,7 +21,7 @@ export class ArticleChatController {
     @Param('articleId') articleId: string,
     @Req() req: any,
   ): Promise<SessionListItemDto[]> {
-    const userId = req.user.userId;
+    const userId = req.user.id;
     const sessions = await this.articleChatService.getSessionsForArticle(
       articleId,
       userId,
@@ -74,7 +74,7 @@ export class ArticleChatController {
     @Param('articleId') articleId: string,
     @Req() req: any,
   ): Promise<{ sessionId: string; message: string }> {
-    const userId = req.user.userId;
+    const userId = req.user.id;
     const newSession = await this.articleChatService.createNewSession(
       articleId,
       userId,

--- a/src/article-chat/article-chat.module.ts
+++ b/src/article-chat/article-chat.module.ts
@@ -5,6 +5,7 @@ import { ArticleChatSession } from './entities/article-chat-session.entity';
 import { ArticleChatMessage } from './entities/article-chat-message.entity';
 import { Article } from '../articles/entities/article.entity';
 import { User } from '../users/entities/user.entity';
+import { ArticleChatController } from '../api/article-chat/article-chat.controller';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { User } from '../users/entities/user.entity';
       User,
     ]),
   ],
+  controllers: [ArticleChatController],
   providers: [ArticleChatService],
   exports: [ArticleChatService],
 })

--- a/src/article-chat/dto/session-list.dto.ts
+++ b/src/article-chat/dto/session-list.dto.ts
@@ -1,0 +1,21 @@
+export interface SessionListItemDto {
+  sessionId: string;
+  title?: string;
+  summary?: string;
+  messageCount: number;
+  lastMessageAt?: Date;
+  isActive: boolean;
+  createdAt: Date;
+}
+
+export interface SessionMessagesDto {
+  sessionId: string;
+  messages: {
+    messageId: string;
+    role: 'user' | 'assistant' | 'system';
+    content: string;
+    timestamp: Date;
+    modelName?: string;
+    totalTokens?: number;
+  }[];
+}

--- a/src/article-chat/services/article-chat.service.ts
+++ b/src/article-chat/services/article-chat.service.ts
@@ -230,4 +230,83 @@ export class ArticleChatService {
       isActive: true,
     });
   }
+
+  /**
+   * 아티클의 모든 세션을 조회합니다 (사용자별)
+   */
+  async getSessionsForArticle(
+    articleId: string,
+    userId: string,
+  ): Promise<ArticleChatSession[]> {
+    return this.sessionRepository.find(
+      {
+        article: { articleId },
+        user: { userId },
+      },
+      {
+        orderBy: { lastMessageAt: 'DESC' },
+      },
+    );
+  }
+
+  /**
+   * 세션의 모든 메시지를 조회합니다
+   */
+  async getSessionMessages(sessionId: string): Promise<ArticleChatMessage[]> {
+    return this.messageRepository.find(
+      { session: { sessionId } },
+      {
+        orderBy: { sequenceNumber: 'ASC' },
+      },
+    );
+  }
+
+  /**
+   * 기존 활성 세션을 비활성화하고 새 세션을 생성합니다
+   */
+  async createNewSession(
+    articleId: string,
+    userId: string,
+  ): Promise<ArticleChatSession> {
+    // 기존 활성 세션 비활성화
+    const activeSessions = await this.sessionRepository.find({
+      article: { articleId },
+      user: { userId },
+      isActive: true,
+    });
+
+    for (const session of activeSessions) {
+      session.isActive = false;
+    }
+
+    await this.em.flush();
+
+    // 아티클과 유저 존재 확인
+    const article = await this.articleRepository.findOne({ articleId });
+    if (!article) {
+      throw new NotFoundException(`Article with ID ${articleId} not found`);
+    }
+
+    const user = await this.userRepository.findOne({ userId });
+    if (!user) {
+      throw new NotFoundException(`User with ID ${userId} not found`);
+    }
+
+    // 새 세션 생성
+    const newSession = new ArticleChatSession();
+    newSession.article = article;
+    newSession.user = user;
+    newSession.isActive = true;
+    newSession.messageCount = 0;
+    newSession.totalTokens = 0;
+    newSession.totalCostUsd = 0;
+
+    await this.em.persistAndFlush(newSession);
+
+    this.logger.log(
+      `Created new chat session ${newSession.sessionId} for article ${articleId}`,
+    );
+
+    return newSession;
+  }
 }

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -2573,7 +2573,7 @@ export class ArticlesService {
                     {
                       role: ChatMessageRole.ASSISTANT,
                       content: aiResponse,
-                      modelName: 'gemini-1.5-flash',
+                      modelName: regenerationResult.modelName,
                       promptTokens: regenerationResult.promptTokens,
                       completionTokens: regenerationResult.completionTokens,
                       totalTokens: regenerationResult.totalTokens,


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-457](https://linear.app/chill-mato/issue/CHI-457/)

## 변경사항 요약
- RegenerateArticleOutput DTO와 관련 서비스에 `modelName` 필드를 도입해 실제 사용 모델을 채팅 히스토리에 남김
- Article Chat 세션 목록/메시지 조회/신규 생성 API를 추가하고 사용자별 필터링·정렬 로직을 구성
- ArticleChatController 라우팅을 글로벌 API prefix 구조(`api/v1/...`)에 맞춰 정합성 확보
- JWT payload에서 `request.user.id`만 참조하도록 통일해 인증 컨텍스트 필드 오류를 방지

## 데이터베이스 변경사항
- 없음

## 빌드 & 배포

### 빌드 확인
- [x] `npm run build`
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음