### PR TITLE
[FIX] Article 조회 응답에 folderId 추가

### DIFF
--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -373,7 +373,7 @@ export class ArticlesService {
     const article = await this.articleRepository.findOne(
       { articleId },
       {
-        populate: ['user', 'archives', 'writingStyle', 'articleScraps.scrap'],
+        populate: ['user', 'archives', 'writingStyle', 'articleScraps.scrap', 'folder'],
         filters: { isDeleted: false },
       },
     );
@@ -410,6 +410,7 @@ export class ArticlesService {
       topic: article.topic,
       keyInsight: article.keyInsight,
       generationParams: article.generationParams,
+      folderId: article.folder?.folderId || null,
       createdAt: article.createdAt,
       updatedAt: article.updatedAt,
       user: article.user,


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: #78 

## 변경사항 요약
Article 상세 조회(`findOneWithDetails`) 시 folderId가 응답에 포함되지 않는 문제를 수정

**변경 내용:**
- `populate` 배열에 `folder` 관계 추가
- 응답 객체에 `folderId` 필드 포함 (`article.folder?.folderId || null`)

## 데이터베이스 변경사항
없음

## 빌드 & 배포

### 빌드 확인
- [x] `npm run build` 성공
- [x] `dist/` 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음