### PR TITLE
feat: User 언어 설정 기반 한국어/영어 프롬프트 직접 생성

### DIFF
--- a/src/ai-workflows/dto/newsletter.dto.ts
+++ b/src/ai-workflows/dto/newsletter.dto.ts
@@ -39,6 +39,7 @@ export interface NewsletterWorkflowInput {
   writingStyleExampleContents?: string[];
   pdfUrlsWithPrompts?: PdfReference[];
   feedbacks?: Feedback[];
+  userLanguage?: string | null; // 'ko' for Korean, 'en' for English
 }
 
 export interface NewsletterWorkflowOutput {

--- a/src/ai-workflows/prompts/newsletter-prompt-templates.service.ts
+++ b/src/ai-workflows/prompts/newsletter-prompt-templates.service.ts
@@ -8,8 +8,12 @@ export class NewsletterPromptTemplatesService {
   private readonly articleReflectorTemplate: PromptTemplate;
   private readonly writingStyleRewriteTemplate: PromptTemplate;
   private readonly structureAnalysisTemplate: PromptTemplate;
-  private readonly languagePreferenceDetectionTemplate: PromptTemplate;
-  private readonly koreanTranslationTemplate: PromptTemplate;
+
+  // Korean-specific templates
+  private readonly koreanNewsletterTemplate: PromptTemplate;
+  private readonly koreanNewsletterTitleTemplate: PromptTemplate;
+  private readonly koreanArticleReflectorTemplate: PromptTemplate;
+  private readonly koreanWritingStyleRewriteTemplate: PromptTemplate;
 
   constructor() {
     this.simpleNewsletterTemplate = PromptTemplate.fromTemplate(`
@@ -171,49 +175,140 @@ Analyze the structure of the given text by heading hierarchy (#, ##, ###, ####),
   ]
 }}`);
 
-    this.languagePreferenceDetectionTemplate =
-      PromptTemplate.fromTemplate(`You are a linguistic analyst who decides whether the author of the newsletter inputs is likely a Korean speaker writing for Korean readers.
-
-Inputs:
-- Topic: {topic}
-- Key Insight: {keyInsight}
-- Generation Parameters: {generationParams}
-
-Guidelines:
-1. Evaluate cultural references, phrasing, and semantics found in the inputs.
-2. Do not assume the user is Korean solely because Hangul appears; weigh overall intent and tone.
-3. If the inputs are entirely in English or explicitly request English output, you must respond with isKoreanUser=false and confidence="low".
-4. Only classify as Korean when there are strong signals (cultural intent, Korean-specific context, explicit request for Korean audience).
-5. Respond with valid JSON only, following this schema:
-   {{
-     "isKoreanUser": boolean,
-     "confidence": "low" | "medium" | "high",
-     "reason": "short explanation in English"
-   }}`);
-
-    this.koreanTranslationTemplate =
-      PromptTemplate.fromTemplate(`당신은 최고의 번역가입니다. 주어진 뉴스레터 제목과 본문을 자연스러운 한국어로 번역하세요.
+    // Korean-specific templates
+    this.koreanNewsletterTemplate = PromptTemplate.fromTemplate(`
+**당신은 최고의 뉴스레터 작가입니다. 주어진 context와 rules에 따라 뉴스레터를 작성해주세요.**
 
 <rules>
-- 제목과 내용 모두 Markdown 형식을 유지하세요.
-- 콘텐츠의 구조와 핵심 메시지를 유지하세요.
-- 번역된 문장은 자연스럽고 유려한 한국어 문체여야 합니다.
-- 전문 용어는 맥락에 맞게 적절한 한국어로 번역하거나 원어를 병기하세요.
+# 기본 규칙
+- 마크다운 형식으로 작성해야 합니다.
+- 독자에게 실질적인 가치를 제공하는 콘텐츠여야 합니다.
+- 친근하면서도 전문적인 어조로 작성해야 합니다.
+- 스크랩 데이터의 핵심 내용을 충실히 반영해야 합니다.
+- 3-5개의 문단으로 구성해야 합니다.
+- **한국어로 작성해야 합니다.**
+- 제목을 통해 섹션을 구분하며, 각 섹션은 최소 1단계 깊이로 작성되어야 합니다.
+- ### #1 형식이 아닌 ### 1. 형식으로 작성합니다.
+- 중요한 내용은 **굵은 글씨**로 강조합니다.
+- 글자 수에 대한 추가 요청이 없다면, 최소 2000자 이상으로 작성해야 합니다.
+- 순서 있는 목록보다 불릿 포인트(•, -, *)를 사용합니다.
+- 수평선은 ***가 아닌 --- 를 사용합니다.
+- 제목 레벨은 # 에서 ### 까지만 사용합니다.
+
+# 구조 템플릿이 주어진 경우
+- 구조 템플릿 각 섹션의 제목과 인사이트를 참고하여 작성합니다.
+- 각 섹션의 하위 항목들을 충실히 반영합니다.
+- 템플릿의 논리적 흐름을 유지하면서 내용을 풍부하게 전개합니다.
+
+# 피드백이 주어진 경우
+- {feedbacks}의 이전 generatedNewsletter와 피드백을 참고하여 개선된 내용을 작성합니다.
+- 지적된 문제점들을 구체적으로 해결합니다.
+
+# 한국어 작성 가이드라인
+- 자연스러운 한국어 표현을 사용합니다.
+- 전문 용어는 독자가 이해하기 쉽게 설명하거나 필요시 영어를 병기합니다.
+- 한국 독자의 문화적 맥락과 관심사를 고려합니다.
+- 문장은 간결하고 명확하게, 한국어 문법에 맞게 작성합니다.
 </rules>
 
 <context>
-Title:
-{title}
+주제: {topic}
+핵심 인사이트: {keyInsight}
+생성 파라미터: {generationParams}
+구조 템플릿: {articleStructureTemplate}
 
-Content:
-{content}
+스크랩 데이터:
+{scrapContent}
+
+PDF 콘텐츠:
+{pdfContent}
+
+피드백:
+{feedbacks}
 </context>
 
 <response format>
-{{
-  "title": "번역된 제목",
-  "content": "번역된 본문 (Markdown 유지)"
-}}
+뉴스레터 본문만 작성하세요. 제목은 포함하지 마세요.
+</response format>`);
+
+    this.koreanNewsletterTitleTemplate = PromptTemplate.fromTemplate(`
+당신은 전문 뉴스레터 작가입니다. 주어진 뉴스레터 콘텐츠에 대한 매력적인 제목을 작성하세요.
+
+주제: {topic}
+핵심 인사이트: {keyInsight}
+생성 파라미터: {generationParams}
+
+뉴스레터 콘텐츠:
+{content}
+
+작성 규칙:
+1. 마크다운을 사용하지 마세요.
+2. 독자의 관심을 끄는 제목을 작성하세요.
+3. 일반 텍스트로 작성하세요.
+4. 최대 50자 이내로 작성하세요 (한국어 기준).
+5. 클릭을 유도하는 호기심 자극 요소를 포함하세요.
+6. 구체적이면서도 간결한 표현을 사용하세요.
+
+위 콘텐츠에 대한 간결하고 매력적인 한국어 제목을 작성하세요.`);
+
+    this.koreanArticleReflectorTemplate = PromptTemplate.fromTemplate(`
+당신은 전문 뉴스레터 에디터입니다. 주제 {topic}과 핵심 인사이트 {keyInsight}에 대한 뉴스레터 콘텐츠 {content}를 읽고, 다음 기준에 따라 깊이 있는 피드백을 작성하세요.
+
+<평가 기준>
+- 기사에서 전달하려는 핵심 메시지가 명확하게 드러나는지 평가합니다.
+- 기사의 구조가 체계적이고 논리적인지 평가합니다.
+- 기사의 어조와 문체가 적절한지 평가합니다.
+- 기사의 내용이 주제와 핵심 인사이트를 충실히 반영하는지 평가합니다.
+- {articleStructureTemplate}의 제목과 아이디어가 적절히 반영되었는지 평가합니다.
+- 한국어 표현의 자연스러움과 가독성을 평가합니다.
+- 독자 관점에서 유용하고 흥미로운 내용인지 평가합니다.
+</평가 기준>
+
+<피드백 작성 가이드>
+- 구체적이고 실행 가능한 개선 제안을 포함하세요.
+- 잘된 점과 개선이 필요한 점을 균형있게 다루세요.
+- 각 평가 항목별로 명확한 의견을 제시하세요.
+- 한국어 문법과 표현에 대한 구체적 조언을 포함하세요.
+</피드백 작성 가이드>
+
+<response format>
+뉴스레터에 대한 피드백**만** 작성하세요.
+</response format>`);
+
+    this.koreanWritingStyleRewriteTemplate = PromptTemplate.fromTemplate(`
+당신은 전문 문체 변환 전문가입니다. 주어진 뉴스레터 콘텐츠를 문체 예시에 따라 재작성하세요.
+
+<규칙>
+- 원본 콘텐츠의 핵심 메시지와 구조는 유지하되, 문체를 변경합니다.
+- 문체 예시의 어조, 스타일, 문장 구조를 분석하여 적용합니다.
+- 마크다운 형식을 유지합니다.
+- 콘텐츠의 논리적 흐름을 유지합니다.
+- **한국어로 작성합니다.**
+- 수평선은 ***가 아닌 --- 를 사용합니다.
+- 불릿 포인트는 '-'를 사용합니다.
+- 표준 마크다운 형식으로 작성합니다.
+
+# 한국어 문체 적용 가이드
+- 예시 문체의 특징적인 어휘 선택 패턴을 파악하여 적용합니다.
+- 문장의 길이와 리듬감을 예시와 유사하게 조정합니다.
+- 높임말 수준(합쇼체/해요체/반말)을 예시와 일치시킵니다.
+- 전문성 수준과 친근감의 균형을 예시에 맞춥니다.
+- 한국어 특유의 표현 방식과 관용구를 적절히 활용합니다.
+</규칙>
+
+<context>
+주제: {topic}
+핵심 인사이트: {keyInsight}
+
+원본 뉴스레터 콘텐츠:
+{content}
+
+문체 예시:
+{writingStyleExamples}
+</context>
+
+<response format>
+문체 예시에 따라 뉴스레터 콘텐츠를 재작성하세요. 제목은 포함하지 마세요.
 </response format>`);
   }
 
@@ -237,11 +332,20 @@ Content:
     return this.structureAnalysisTemplate;
   }
 
-  getLanguagePreferenceDetectionTemplate(): PromptTemplate {
-    return this.languagePreferenceDetectionTemplate;
+  // Korean-specific template getters
+  getKoreanNewsletterTemplate(): PromptTemplate {
+    return this.koreanNewsletterTemplate;
   }
 
-  getKoreanTranslationTemplate(): PromptTemplate {
-    return this.koreanTranslationTemplate;
+  getKoreanNewsletterTitleTemplate(): PromptTemplate {
+    return this.koreanNewsletterTitleTemplate;
+  }
+
+  getKoreanArticleReflectorTemplate(): PromptTemplate {
+    return this.koreanArticleReflectorTemplate;
+  }
+
+  getKoreanWritingStyleRewriteTemplate(): PromptTemplate {
+    return this.koreanWritingStyleRewriteTemplate;
   }
 }

--- a/src/ai-workflows/services/newsletter-streaming.service.ts
+++ b/src/ai-workflows/services/newsletter-streaming.service.ts
@@ -85,10 +85,7 @@ export class NewsletterStreamingService extends NewsletterWorkflowService {
           });
         });
 
-        await this.runStep(streaming, NodeName.ADAPT_LOCALE, async () => {
-          const update = await this.adaptLocaleNode(state);
-          this.applyStateUpdate(state, update);
-        });
+        // adaptLocaleNode removed: userLanguage now determines language from the start
 
         streaming.emitProgress({
           node: 'workflow',

--- a/src/ai-workflows/services/newsletter-workflow.service.ts
+++ b/src/ai-workflows/services/newsletter-workflow.service.ts
@@ -24,8 +24,6 @@ const VERTEX_MODEL_TITLE = 'gemini-2.5-flash';
 const VERTEX_MODEL_REFLECTOR = 'gemini-2.5-flash';
 const VERTEX_MODEL_REWRITE = 'gemini-2.5-flash';
 const VERTEX_MODEL_PDF = 'gemini-2.0-flash-lite';
-const VERTEX_MODEL_LANGUAGE_DETECTION = 'gemini-2.5-flash';
-const VERTEX_MODEL_TRANSLATION = 'gemini-2.5-flash';
 
 const MAX_PDF_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
 const PDF_DOWNLOAD_TIMEOUT_MS = 60_000;
@@ -48,6 +46,7 @@ export interface WorkflowState {
   title: string;
   content: string;
   analysisReason: string;
+  userLanguage: string; // 'ko' for Korean, 'en' for English
 }
 
 export type WorkflowUpdate = Partial<WorkflowState> & {
@@ -57,16 +56,6 @@ export type WorkflowUpdate = Partial<WorkflowState> & {
   feedbacks?: Feedback[];
 };
 
-const LanguageDetectionSchema = z.object({
-  isKoreanUser: z.boolean(),
-  confidence: z.enum(['low', 'medium', 'high']),
-  reason: z.string().optional().nullable(),
-});
-
-const TranslationSchema = z.object({
-  title: z.string().optional(),
-  content: z.string(),
-});
 
 const LIST_MERGE_KEYS = new Set<keyof WorkflowState>([
   'processingSteps',
@@ -107,11 +96,6 @@ export class NewsletterWorkflowService {
   private readonly reflectorModel: ChatVertexAI;
   private readonly rewriteModel: ChatVertexAI;
   private readonly pdfModel: ChatVertexAI;
-  private readonly languageDetectionModel: ChatVertexAI;
-  private readonly translationModel: ChatVertexAI;
-
-  private readonly detectionPrompt: PromptTemplate;
-  private readonly translationPrompt: PromptTemplate;
 
   constructor(
     private readonly vertexFactory: VertexAiFactory,
@@ -144,21 +128,6 @@ export class NewsletterWorkflowService {
       temperature: 0.4,
       thinkingBudget: 0,
     });
-    this.languageDetectionModel = this.vertexFactory.buildChat({
-      model: VERTEX_MODEL_LANGUAGE_DETECTION,
-      temperature: 0.1,
-      thinkingBudget: -1,
-    });
-    this.translationModel = this.vertexFactory.buildChat({
-      model: VERTEX_MODEL_TRANSLATION,
-      temperature: 0.2,
-      thinkingBudget: -1,
-    });
-
-    this.detectionPrompt =
-      this.promptTemplates.getLanguagePreferenceDetectionTemplate();
-    this.translationPrompt =
-      this.promptTemplates.getKoreanTranslationTemplate();
   }
 
   protected createInitialState(
@@ -182,6 +151,7 @@ export class NewsletterWorkflowService {
       title: '',
       content: '',
       countOfReflector: 0,
+      userLanguage: input.userLanguage ?? 'en', // Default to English
     };
   }
 
@@ -226,7 +196,7 @@ export class NewsletterWorkflowService {
     this.applyStateUpdate(state, this.aggregatorNode(state));
     await this.generateWithIterations(state);
     this.applyStateUpdate(state, await this.generateTitleNode(state));
-    this.applyStateUpdate(state, await this.adaptLocaleNode(state));
+    // adaptLocaleNode removed: userLanguage now determines language from the start
   }
 
   protected async generateWithIterations(state: WorkflowState): Promise<void> {
@@ -511,8 +481,12 @@ export class NewsletterWorkflowService {
     try {
       const feedbacks = state.feedbacks ?? [];
       const articleStructure = state.articleStructureTemplate ?? [];
+      const isKorean = state.userLanguage === 'ko';
 
-      const template = this.promptTemplates.getSimpleNewsletterTemplate();
+      const template = isKorean
+        ? this.promptTemplates.getKoreanNewsletterTemplate()
+        : this.promptTemplates.getSimpleNewsletterTemplate();
+
       const prompt = await template.format({
         topic: state.topic ?? '',
         keyInsight: state.keyInsight ?? 'Empty',
@@ -548,7 +522,12 @@ export class NewsletterWorkflowService {
     state: WorkflowState,
   ): Promise<WorkflowUpdate> {
     try {
-      const template = this.promptTemplates.getSimpleNewsletterTitleTemplate();
+      const isKorean = state.userLanguage === 'ko';
+
+      const template = isKorean
+        ? this.promptTemplates.getKoreanNewsletterTitleTemplate()
+        : this.promptTemplates.getSimpleNewsletterTitleTemplate();
+
       const prompt = await template.format({
         topic: state.topic ?? '',
         keyInsight: state.keyInsight ?? 'Empty',
@@ -574,7 +553,12 @@ export class NewsletterWorkflowService {
     state: WorkflowState,
   ): Promise<WorkflowUpdate> {
     try {
-      const template = this.promptTemplates.getArticleReflectorTemplate();
+      const isKorean = state.userLanguage === 'ko';
+
+      const template = isKorean
+        ? this.promptTemplates.getKoreanArticleReflectorTemplate()
+        : this.promptTemplates.getArticleReflectorTemplate();
+
       const prompt = await template.format({
         topic: state.topic ?? 'Empty',
         keyInsight: state.keyInsight ?? 'Empty',
@@ -618,7 +602,12 @@ export class NewsletterWorkflowService {
         };
       }
 
-      const template = this.promptTemplates.getWritingStyleRewriteTemplate();
+      const isKorean = state.userLanguage === 'ko';
+
+      const template = isKorean
+        ? this.promptTemplates.getKoreanWritingStyleRewriteTemplate()
+        : this.promptTemplates.getWritingStyleRewriteTemplate();
+
       const prompt = await template.format({
         topic: state.topic ?? '',
         keyInsight: state.keyInsight ?? 'Empty',
@@ -639,95 +628,6 @@ export class NewsletterWorkflowService {
         processingSteps: ['writing_style_rewrite'],
         warnings: ['Writing style rewrite error. Proceed with the original content.'],
         errors: ['Writing style rewrite error.'],
-      };
-    }
-  }
-
-  protected async adaptLocaleNode(
-    state: WorkflowState,
-  ): Promise<WorkflowUpdate> {
-    try {
-      const prompt = await this.detectionPrompt.format({
-        topic: state.topic ?? '',
-        keyInsight: state.keyInsight ?? '',
-        generationParams: state.generationParams ?? '',
-      });
-
-      const rawDetection = await this.languageDetectionModel.invoke(prompt);
-      const detectionText = this.extractMessageText(rawDetection);
-
-      const detectionResult = this.safeJsonParse(
-        detectionText,
-        LanguageDetectionSchema,
-      );
-
-      if (!detectionResult) {
-        return {
-          analysisReason: state.analysisReason ?? 'AI system generated newsletter.',
-          processingSteps: ['locale_adaptation'],
-          warnings: ['Locale adaptation skipped due to uncertain detection result.'],
-        };
-      }
-
-      this.logger.log(
-        `Language preference detection: isKoreanUser=${detectionResult.isKoreanUser}, confidence=${detectionResult.confidence}, reason=${detectionResult.reason}`,
-      );
-
-      const shouldTranslate =
-        detectionResult.isKoreanUser &&
-        ['medium', 'high'].includes(detectionResult.confidence);
-
-      const baseReason =
-        state.analysisReason ?? 'AI system generated newsletter.';
-
-      if (!shouldTranslate) {
-        const updatedReason = detectionResult.reason
-          ? `${baseReason}\n\nLocale decision: ${detectionResult.reason}`.trim()
-          : baseReason;
-
-        return {
-          analysisReason: updatedReason,
-          processingSteps: ['locale_adaptation'],
-        };
-      }
-
-      const translationPrompt = await this.translationPrompt.format({
-        title: state.title ?? '',
-        content: state.content ?? '',
-      });
-
-      const rawTranslation = await this.translationModel.invoke(
-        translationPrompt,
-      );
-      const translationText = this.extractMessageText(rawTranslation);
-
-      const translationResult = this.safeJsonParse(
-        translationText,
-        TranslationSchema,
-      );
-
-      if (!translationResult) {
-        return {
-          processingSteps: ['locale_adaptation'],
-          warnings: ['Translation failed. Content kept in English.'],
-        };
-      }
-
-      const updatedReason = `${baseReason}\n\nTranslated to Korean because: ${
-        detectionResult.reason ?? 'User likely prefers Korean content.'
-      }`.trim();
-
-      return {
-        title: translationResult.title ?? state.title ?? '',
-        content: translationResult.content ?? state.content ?? '',
-        analysisReason: updatedReason,
-        processingSteps: ['locale_adaptation'],
-      };
-    } catch (error) {
-      this.logger.error('Locale adaptation error', error as Error);
-      return {
-        processingSteps: ['locale_adaptation'],
-        warnings: ['Locale adaptation failed. Content kept in English.'],
       };
     }
   }

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -240,6 +240,7 @@ export class ArticlesService {
         generationParams: generateDto.generationParams,
         articleStructureTemplate: generateDto.articleStructureTemplate,
         writingStyleExampleContents,
+        userLanguage: user.language,
       });
 
     // 아티클 저장
@@ -986,6 +987,7 @@ export class ArticlesService {
           generationParams: generateDto.generationParams,
           articleStructureTemplate: generateDto.articleStructureTemplate,
           writingStyleExampleContents,
+          userLanguage: article.user.language,
         });
 
       // AI 생성 결과를 아카이브에 저장
@@ -1319,6 +1321,7 @@ export class ArticlesService {
           writingStyleExampleContents,
           // V3에서 추가: PDF 업로드 정보
           pdfUrlsWithPrompts: pdfUploadsWithPrompts, // 이 부분은 newsletterAgentService에서 지원해야 함
+          userLanguage: article.user.language,
         });
 
       // AI 생성 결과를 아카이브에 저장
@@ -1559,6 +1562,7 @@ export class ArticlesService {
             articleStructureTemplate: generateDto.articleStructureTemplate,
             writingStyleExampleContents,
             pdfUrlsWithPrompts: pdfUploadsWithPrompts,
+            userLanguage: user.language,
           };
 
           const stream = this.newsletterAgentService.generateNewsletterStream(


### PR DESCRIPTION
## 연관 이슈
Closes: #80

## 변경사항 요약
User의 language 설정에 따라 처음부터 해당 언어 프롬프트로 뉴스레터를 생성하도록 개선

- 한국어 프롬프트 템플릿 4종 추가
- 언어별 프롬프트 선택 로직 구현
- 불필요한 번역 단계 제거

## 데이터베이스 변경사항
없음

## 빌드 & 배포

### 빌드 확인
- [x] npm run build 성공
- [x] dist/ 폴더 정상 생성
- [x] TypeScript 컴파일 에러 없음